### PR TITLE
Workbook exporting utils.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "workbooks"]
+	path = workbooks
+	url = git@github.com:ess-dmsc-dram/dmsc-school-notebooks.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# DMSC School Lecture Materials
+
+## How to export workbook from lecture materials
+
+There is a python script `update_workbook.py` to create a workbook(jupyter notebook) from the jupyter notebook lecture materials.
+
+If a jupyter notebook cell has a `solution` tag, it deletes the sources of the cell and leave `Try it yourself: ` message instead.
+
+It creates or deletes workbooks from the lecture materials.
+And the name of the workbook files are same as the lecture materials.
+
+If there is a python file in the lecture material directories,
+it also copies python files into the [workbook submodule](github.com:ess-dmsc-dram/dmsc-school-notebooks).
+
+Once you update the workbook, you have to commit and push the changes of the submodule manually.
+
+
+```
+git submodule
+python update_workbook.py --all  # Update all workbooks
+
+# or
+python update_workbook.py  # Update based on git status
+```
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 There is a python script `update_workbook.py` to create a workbook(jupyter notebook) from the jupyter notebook lecture materials.
 
-If a jupyter notebook cell has a `solution` tag, it deletes the sources of the cell and leave `Try it yourself: ` message instead.
+If a jupyter notebook cell has a `solution` tag, it deletes the sources of the cell and leaves a message instead.
 
 It creates or deletes workbooks from the lecture materials.
 And the name of the workbook files are same as the lecture materials.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Once you update the workbook, you have to commit and push the changes of the sub
 
 
 ```
-git submodule
+git submodule update  # Use --init tag if it is the first time pulling submodule
 python update_workbook.py --all  # Update all workbooks
 
 # or

--- a/scipp/sans-reduction.ipynb
+++ b/scipp/sans-reduction.ipynb
@@ -3,7 +3,13 @@
   {
    "cell_type": "markdown",
    "id": "403b137b-6d4c-4d44-8a36-45c3380e74b1",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "# SANS data reduction\n",
     "\n",
@@ -141,7 +147,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5b4e0704-015c-47a1-a591-b9685eee9072",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from scippneutron.conversion.graph.beamline import beamline\n",
@@ -203,7 +215,13 @@
   {
    "cell_type": "markdown",
    "id": "2f24c81d-09ce-47fb-ab85-373f2a38facb",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Exercise 1: convert raw data to $Q$\n",
     "\n",
@@ -225,7 +243,13 @@
   {
    "cell_type": "markdown",
    "id": "064ea76d-0138-4629-8d8a-71520192933c",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "**Solution:**"
    ]
@@ -235,8 +259,13 @@
    "execution_count": null,
    "id": "f4b5288c-8194-43ea-b375-e25d8a67a3c0",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
-     "hide-cell"
+     "hide-cell",
+     "solution"
     ]
    },
    "outputs": [],
@@ -340,8 +369,13 @@
    "execution_count": null,
    "id": "4dbd1772-d92c-402a-88d2-1c2bf93fae51",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
-     "hide-cell"
+     "hide-cell",
+     "solution"
     ]
    },
    "outputs": [],
@@ -390,6 +424,10 @@
    "execution_count": null,
    "id": "5da8bd92-7158-43ad-b59b-c67fb9542069",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "raises-exception",
      "hide-cell"
@@ -405,8 +443,13 @@
    "execution_count": null,
    "id": "b5fb61a8-514d-49bc-8987-044a183309ef",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
-     "hide-cell"
+     "hide-cell",
+     "solution"
     ]
    },
    "outputs": [],
@@ -429,7 +472,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5750dd8a-a445-44d0-84a2-18eb9433e92b",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "normed.plot(norm='log')"
@@ -535,7 +584,13 @@
   {
    "cell_type": "markdown",
    "id": "a3bd4ba9-725c-4afb-94ca-973170aee3a3",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Instead of reading the bin edges off the figure above,\n",
     "you should try to compute your bin edges in a way that is based on some known parameters of your simulation (e.g. wavelength range) as well as the physical layout of the instrument.\n",
@@ -561,8 +616,13 @@
    "execution_count": null,
    "id": "2e75dbbb-bf20-4962-8549-d6fd2a6a0f97",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
-     "hide-cell"
+     "hide-cell",
+     "solution"
     ]
    },
    "outputs": [],
@@ -603,7 +663,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7005208b-8adb-4a7a-b5fc-1a9ce9c5e766",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "folded.hist(tof=200, y=200).plot(norm='log', vmin=1.0e-2)"
@@ -613,7 +679,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "521fd4cb-2a72-469a-9734-ece691f5c5dc",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "folded_h.plot(norm='log', vmin=1.0)"
@@ -624,6 +696,10 @@
    "execution_count": null,
    "id": "32e5e10d-b25d-48cc-bc43-bdc7c9427260",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-cell"
     ]
@@ -647,6 +723,10 @@
    "execution_count": null,
    "id": "7511e4e8-c73b-4997-bd87-e93cfdc9b760",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-cell"
     ]
@@ -661,7 +741,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "70859506-bedc-41eb-ac61-687c2e7312d6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pp.plot({'1-pulse': normed, '3-pulses': folded_normed}, norm='log')"
@@ -707,7 +793,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/update_workbook.py
+++ b/update_workbook.py
@@ -1,9 +1,7 @@
 import json
-from dataclasses import dataclass
 from enum import auto, Enum
 from pathlib import Path
 from types import MappingProxyType
-from typing import Optional
 
 
 # Configuration Variables
@@ -138,21 +136,6 @@ def tags_in(cell: dict[str, dict], *tags: str) -> bool:
 
 def is_solution_cell(cell: dict[str, dict]) -> bool:
     return tags_in(cell, 'solution')
-
-
-def _get_or_make(obj: dict, key: str) -> dict:
-    if key not in obj:
-        obj[key] = dict()
-        return obj[key]
-    return obj[key]
-
-
-def mkdict(obj: dict, key: str, /, *args: str) -> dict:
-    child_obj = _get_or_make(obj, key)
-    if not args:
-        return child_obj
-    else:
-        return mkdict(child_obj, *args)
 
 
 class Textbook:

--- a/update_workbook.py
+++ b/update_workbook.py
@@ -197,7 +197,7 @@ class Textbook:
             self.workbook_path.parent.mkdir(parents=True)
 
         with open(self.workbook_path, 'w') as file:
-            json.dump(self.workbook, file)
+            json.dump(self.workbook, file, indent=1)
 
 
 def filter_textbooks(changed_files: dict) -> dict[Path, GitStatus]:

--- a/update_workbook.py
+++ b/update_workbook.py
@@ -9,6 +9,7 @@ SYNC_FILE_SUFFIXES = ('.py', '.ipynb')
 WORKBOOK_ROOT_DIR = Path('workbooks')
 SOURCE_REPLACEMENT_MESSAGE = '# Insert your solution:\n'
 
+
 class GitStatus(Enum):
     DELETED = auto()
     MODIFIED = auto()
@@ -16,12 +17,14 @@ class GitStatus(Enum):
     UNTRACKED = auto()
     TOUCHED = auto()
 
+
 git_prefix_to_status = MappingProxyType({
     'D  ': GitStatus.DELETED,
     ' M ': GitStatus.MODIFIED,
     'A  ': GitStatus.ADDED,
     '?? ': GitStatus.UNTRACKED
 })
+
 
 class Lecture(Enum):
     MCSTAS = auto()
@@ -31,6 +34,7 @@ class Lecture(Enum):
     SCICAT = auto()
     SCIPP = auto()
 
+
 lecture_to_directories = MappingProxyType({
     Lecture.MCSTAS: Path('mcstas'),
     Lecture.MODEL: Path('model'),
@@ -39,6 +43,7 @@ lecture_to_directories = MappingProxyType({
     Lecture.SCICAT: Path('scicat'),
     Lecture.SCIPP: Path('scipp'),
 })
+
 
 # Helper Utilities
 # Helper - Git
@@ -117,10 +122,6 @@ def get_all_materials() -> dict:
 
     return materials
 
-def export_requirements() -> None:
-    """Copy requirements.txt to the workbook directory."""
-    import shutil
-    shutil.copy("requirements.txt", WORKBOOK_ROOT_DIR)
 
 def export_python_material(textbook_path: Path) -> None:
     """Copy python materials to the workbook directory."""
@@ -225,7 +226,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     check_current_dir()
-    export_requirements()
 
     if args.scope_all:
         candidates = get_all_materials()

--- a/update_workbook.py
+++ b/update_workbook.py
@@ -117,6 +117,10 @@ def get_all_materials() -> dict:
 
     return materials
 
+def export_requirements() -> None:
+    """Copy requirements.txt to the workbook directory."""
+    import shutil
+    shutil.copy("requirements.txt", WORKBOOK_ROOT_DIR)
 
 def export_python_material(textbook_path: Path) -> None:
     """Copy python materials to the workbook directory."""
@@ -219,7 +223,9 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument('-a', '--all', dest="scope_all", help="Update all workbooks.", action="store_true")
     args = parser.parse_args()
+    
     check_current_dir()
+    export_requirements()
 
     if args.scope_all:
         candidates = get_all_materials()

--- a/update_workbook.py
+++ b/update_workbook.py
@@ -9,7 +9,7 @@ from typing import Optional
 # Configuration Variables
 SYNC_FILE_SUFFIXES = ('.py', '.ipynb')
 WORKBOOK_ROOT_DIR = Path('workbooks')
-SOURCE_REPLACEMENT_MESSAGE = '# Try it yourself:\n'
+SOURCE_REPLACEMENT_MESSAGE = '# Insert your solution:\n'
 
 class GitStatus(Enum):
     DELETED = auto()

--- a/update_workbook.py
+++ b/update_workbook.py
@@ -1,0 +1,249 @@
+import json
+from dataclasses import dataclass
+from enum import auto, Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Optional
+
+
+# Configuration Variables
+SYNC_FILE_SUFFIXES = ('.py', '.ipynb')
+WORKBOOK_ROOT_DIR = Path('workbooks')
+SOURCE_REPLACEMENT_MESSAGE = '# Try it yourself:\n'
+
+class GitStatus(Enum):
+    DELETED = auto()
+    MODIFIED = auto()
+    ADDED = auto()
+    UNTRACKED = auto()
+    TOUCHED = auto()
+
+git_prefix_to_status = MappingProxyType({
+    'D  ': GitStatus.DELETED,
+    ' M ': GitStatus.MODIFIED,
+    'A  ': GitStatus.ADDED,
+    '?? ': GitStatus.UNTRACKED
+})
+
+class Lecture(Enum):
+    MCSTAS = auto()
+    MODEL = auto()
+    PROPOSALS = auto()
+    PYTHONBASICS = auto()
+    SCICAT = auto()
+    SCIPP = auto()
+
+lecture_to_directories = MappingProxyType({
+    Lecture.MCSTAS: Path('mcstas'),
+    Lecture.MODEL: Path('model'),
+    Lecture.PROPOSALS: Path('proposals'),
+    Lecture.PYTHONBASICS: Path('python'),
+    Lecture.SCICAT: Path('scicat'),
+    Lecture.SCIPP: Path('scipp'),
+})
+
+# Helper Utilities
+# Helper - Git
+def run_git_command(*args: str) -> str:
+    import subprocess
+    if 'rm' in args and '--cached' not in args:
+        raise RuntimeError("Using `git rm` without --cached option is not allowed.")
+
+    return subprocess.run(['git', *args], stdout=subprocess.PIPE, text=True).stdout
+
+
+def git_changed_files(git_base: str = './') -> dict[Path, GitStatus]:
+    git_status = run_git_command('-C', git_base, 'status', '-s')
+    return {
+        Path(file_status[3:]): git_prefix_to_status[status]
+        for file_status in git_status.split('\n')
+        if (status:=file_status[:3]) in git_prefix_to_status
+    }
+
+
+def git_root() -> Path:
+    git_root = run_git_command('rev-parse', '--show-toplevel')
+    return Path(git_root.rstrip())
+
+
+def report_updates() -> None:
+    changed_list = git_changed_files(git_base=str(WORKBOOK_ROOT_DIR))
+
+    if changed_list:
+        print("Updates done.")
+        print("There are updates in the workbooks to be committed.")
+        
+        print("\nHint:\n",
+            "cd workbooks\n",
+            *(f"git add {str(filepath)}\n" for filepath in changed_list),
+            "git commit -m '{COMMITMESSAGE}'\n",
+            "git push origin {BRANCHNAME}")
+    else:
+        print("Nothing to update.")
+
+
+# Helper - System Commands
+def check_current_dir():
+    import os
+    if (cur_file_dir:=Path(__file__).parent) != git_root() \
+        or cur_file_dir != Path(os.getcwd()):
+        raise RuntimeError("`update_workbook` should be run in "
+                           "the `dmsc-school` root directory, where this script is."
+                           f"hint: cd {cur_file_dir.resolve()}")
+
+
+def listmaterials(root_dir: Path) -> list:
+    import os
+    materials = []
+    for lecture_dir in lecture_to_directories.values():
+        try:
+            file_paths = os.listdir(root_dir/lecture_dir)
+            materials.extend([lecture_dir/Path(file_path) for file_path in file_paths])
+        except FileNotFoundError:
+            ...
+    
+    return materials
+
+
+def get_all_materials() -> dict:
+    textbook_list = listmaterials(root_dir=Path('./'))
+    workbook_list = listmaterials(root_dir=WORKBOOK_ROOT_DIR)
+
+    materials = dict()
+    for workbook in workbook_list:
+        if workbook not in textbook_list:
+            materials[workbook] = GitStatus.DELETED
+
+    for textbook in textbook_list:
+        materials[textbook] = GitStatus.TOUCHED
+
+    return materials
+
+
+def export_python_material(textbook_path: Path) -> None:
+    """Copy python materials to the workbook directory."""
+    import shutil
+    shutil.copy(textbook_path, WORKBOOK_ROOT_DIR/textbook_path.parent)
+
+
+# Helper - Jupyter Contents
+def retrieve_tags(cell: dict[str, dict]) -> list:
+    return meta.get('tags', []) if (meta:=cell.get('metadata')) else []
+
+
+def tags_in(cell: dict[str, dict], *tags: str) -> bool:
+    return (cell_tags:=retrieve_tags(cell)) is not None and \
+            all([tag in cell_tags for tag in tags])
+
+
+def is_solution_cell(cell: dict[str, dict]) -> bool:
+    return tags_in(cell, 'solution')
+
+
+def _get_or_make(obj: dict, key: str) -> dict:
+    if key not in obj:
+        obj[key] = dict()
+        return obj[key]
+    return obj[key]
+
+
+def mkdict(obj: dict, key: str, /, *args: str) -> dict:
+    child_obj = _get_or_make(obj, key)
+    if not args:
+        return child_obj
+    else:
+        return mkdict(child_obj, *args)
+
+
+class Textbook:
+    """Jpyter notebook for lectures."""
+    def __init__(self, rel_path: Path) -> None:
+        self.rel_path = rel_path
+        self.contents = self._load_contents()
+        self.workbook_path = WORKBOOK_ROOT_DIR/self.rel_path
+        self.workbook = self._create_workbook_contents()
+
+    def _create_workbook_contents(self) -> dict:
+        """
+        Update workbook(ipynb) from the textbook contents.
+
+        How to create a workbook from a textbook
+        ----------------------------------------
+        For all cells with ``solution`` tag,
+        remove ``source`` of the cell and ``hide-cell``, ``solution`` tags and
+        add ``SOURCE_REPLACEMENTM_MESSAE`` to the ``source``.
+        """
+        from copy import deepcopy
+        workbook = deepcopy(self.contents)
+        solution_cells = filter(is_solution_cell, workbook.get('cells', []))
+        
+        for solution in solution_cells:
+            solution['source'] = [SOURCE_REPLACEMENT_MESSAGE]
+            tags = retrieve_tags(solution)
+            for tag in ('hide-cell', 'solution'):
+                if tag in tags:
+                    tags.remove(tag)
+            if 'workbook' not in tags:
+                tags.append('workbook')
+
+        return workbook
+
+    def _load_contents(self) -> dict:
+        with open(self.rel_path) as file:
+            return json.load(file)
+    
+    def export_workbook(self) -> None:
+        if not self.workbook_path.parent.exists():
+            self.workbook_path.parent.mkdir(parents=True)
+
+        with open(self.workbook_path, 'w') as file:
+            json.dump(self.workbook, file)
+
+
+def filter_textbooks(changed_files: dict) -> dict[Path, GitStatus]:
+    changed_materials = {
+        filepath: status
+        for filepath, status in changed_files.items()
+        if filepath.suffix in SYNC_FILE_SUFFIXES
+    }
+    lecture_dirs = lecture_to_directories.values()
+    return {
+        file_path: status
+        for file_path, status in changed_materials.items()
+        if file_path.parent in lecture_dirs
+    }
+
+
+def delete_workbook(workbook_path: Path):
+    if workbook_path.exists():
+        run_git_command('-C', str(WORKBOOK_ROOT_DIR), 'rm', '--cached', str(workbook_path))
+
+
+def update_workbooks(textbooks: dict):
+    
+    for textbook_path, status in textbooks.items():
+        if status == GitStatus.DELETED:
+            delete_workbook(textbook_path)
+        elif textbook_path.suffix == '.py':
+            export_python_material(textbook_path)
+        else:  # jupyter notebooks
+            textbook = Textbook(textbook_path)
+            textbook.export_workbook()
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+    parser = ArgumentParser()
+    parser.add_argument('-a', '--all', dest="scope_all", help="Update all workbooks.", action="store_true")
+    args = parser.parse_args()
+    check_current_dir()
+
+    if args.scope_all:
+        candidates = get_all_materials()
+    else:
+        candidates = git_changed_files()
+    
+    textbooks = filter_textbooks(candidates)
+    update_workbooks(textbooks)
+    report_updates()
+


### PR DESCRIPTION
`update_workbook.py` script will export workbooks to `dmsc-school-notebook`.
It copies and pastes all jupyter notebooks and python files from `mcstas`, `proposals`, `python`, `scicat` and `scipp` directories.
It will delete source code of the cells if they a tag, `solution` and replace it with an empty cell.

I added `solution` tag to `sans-reduction` as an example.

More details and how-to-use is in the `README.md`.
```
python update_workbook.py --all
# or, if you only want to update updated files in git status,
python update_workbook.py
```