### PR TITLE
Add timeout to gh actions workflow

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Some builds are hanging (seems to be something with the `ipywidgets` notebook, but also the Scipp introduction).
We add a timeout to avoid them running for 6 hours.