### PR TITLE
Editable hint cells in workbooks (a new tag ``dmsc-school-hint`` for exporting workbook with hint cells)

### DIFF
--- a/6-scicat/9-exercise.ipynb
+++ b/6-scicat/9-exercise.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9ac76e6f-c896-43b7-bdd6-5808b22bc7b8",
    "metadata": {},
@@ -34,6 +35,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "49c39c47-c770-499a-a0d0-205fab11d274",
    "metadata": {},
@@ -56,6 +58,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a0694c31-d5ef-4111-bc3d-b639b0da2a02",
    "metadata": {},
@@ -76,6 +79,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1fcebbba-a5eb-4678-a160-fbce79c2e34c",
    "metadata": {},
@@ -101,7 +105,9 @@
    "execution_count": null,
    "id": "aecee7a2-9017-402f-addb-4779734ad313",
    "metadata": {
-    "tags": []
+    "tags": [
+     "dmsc-school-hint"
+    ]
    },
    "outputs": [],
    "source": [
@@ -109,6 +115,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f76b33e2-35d4-4972-9dd8-b691801fdc5f",
    "metadata": {
@@ -131,6 +138,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6cee9ed4-c0d4-4a97-9a0e-9ad95906005f",
    "metadata": {},
@@ -143,7 +151,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4285dd17-be05-4e33-b5e7-583b315d2980",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "dmsc-school-hint"
+    ]
+   },
    "outputs": [],
    "source": [
     "sftp_username = \"dss2023\"\n",
@@ -151,6 +163,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ef0e3ee-9d47-4956-8f72-a8dfefa1d0c4",
    "metadata": {},
@@ -180,6 +193,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9fae2628-61fc-4461-8ad8-dd302c92a677",
    "metadata": {},
@@ -204,6 +218,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3fc00987-aa16-4a6e-9c5e-4d7af42efc1b",
    "metadata": {},
@@ -223,6 +238,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6d687336-fc71-4b37-962e-72ba173027b4",
    "metadata": {},
@@ -275,6 +291,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a57e8d34-2c87-49a7-855e-5f2013148a99",
    "metadata": {},
@@ -306,6 +323,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "85edf358-e4b1-47c8-a847-d92c088b963a",
    "metadata": {},
@@ -329,6 +347,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "63d17fe9-d3c9-41e1-a98e-d96850cd6b50",
    "metadata": {},
@@ -346,6 +365,7 @@
    "source": []
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2534e64c-6cc2-4815-8bfb-b207a73ddd69",
    "metadata": {},
@@ -365,6 +385,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "49616d76-3a16-47bd-ac10-4c7e4fd8f991",
    "metadata": {},
@@ -394,6 +415,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b44210c3-8a81-49a6-9ae3-7f404037d403",
    "metadata": {},
@@ -411,6 +433,7 @@
    "source": []
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "aee918ed-de00-4218-a4ad-3cb487a1d52d",
    "metadata": {},
@@ -432,6 +455,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "80ab81a8-1355-45d4-b128-fa1cb6c6b25e",
    "metadata": {},

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ There are a few tags that are often used. See [this page](https://jupyterbook.or
     Solution of the exercise. Source code will be replaced with a instruction message.
 - `remove-cell`:
     Not included in the workbooks. Also used by `jupyter-book`.
+- `dmsc-school-hint`:
+    Editable cell with hints for students.
+    The tagged cell in the workbook will not be read-only,
+    unless it is already read-only in the textbook.
 - `dmsc-school-keep`: 
     Will not be edited or removed. It overwrites all other tags.
 
@@ -52,6 +56,9 @@ There are a few tags that are often used. See [this page](https://jupyterbook.or
 There is a python script `update_workbook.py` to create a workbook(jupyter notebook)
 from the jupyter notebook lecture materials in [course directories](#Course-Directories)
 based on the [tags](#Workbook-tags) of each cells.
+
+All cells in the workbook will be read-only by default except for `solution` cells.
+Cells can be tagged with `dmsc-shool-hint` to keep their editability.
 
 If there is python files, or image files('*.png', '*.jpg', '*.svg') in the lecture material directories,
 it also copies them into the [workbook submodule](github.com:ess-dmsc-dram/dmsc-school-notebooks).

--- a/update_workbook.py
+++ b/update_workbook.py
@@ -168,6 +168,10 @@ def is_hidden_solution_cell(cell_tags: list[str]) -> bool:
     return check_tags(cell_tags, {'solution': True, CELL_PROTECTING_TAG: False})
 
 
+def is_editable_hint_cell(cell_tags: list[str]) -> bool:
+    return check_tags(cell_tags, {'dmsc-school-hint': True})
+
+
 def clear_outputs(cell: dict[str, Any]) -> None:
     if cell.get('execution_count') is not None:
         cell['execution_count'] = None
@@ -207,11 +211,14 @@ class Textbook:
         How to create a workbook from a textbook
         ----------------------------------------
         For all cells without ``dmsc-school-keep`` tag (``CELL_PROTECTING_TAG``).
-        1. Remove all cells containing ``remove-cell``.
-        2. Replace source code with ``SOURCE_REPLACEMENTM_MESSAE``
-           of all cells containing ``solution`` tags,
-           and replace ``hide-cell``, ``solution`` tags with ``workbook`` tag.
+        - Remove all cells containing ``remove-cell``.
+        - Replace source code with ``SOURCE_REPLACEMENTM_MESSAE``
+          of all cells containing ``solution`` tags,
+          and replace ``hide-cell``, ``solution`` tags with ``workbook`` tag.
         
+        For all cells, turn them into read-only,
+        if they are not cleared ``solution`` cells or tagged with ``dmsc-school-hint`.
+
         """
         from copy import deepcopy
         workbook = deepcopy(self.contents)
@@ -222,7 +229,7 @@ class Textbook:
             if is_hidden_solution_cell((cell_tags:=retrieve_tags(cell))):
                 remove_solution_source(cell)
                 update_solution_tags(cell_tags)
-            else:
+            elif not is_editable_hint_cell(cell_tags):
                 freeze_cell(cell)
 
         return workbook


### PR DESCRIPTION
A new tag ``dmsc-school-hint`` was added to keep the cell editable in the workbooks, so that students can edit the tagged cell in the workbook without copying+pasting themselves.
(All other cells except for cleared solution cells are read-only by default)

Here is the example of exported workbook with updated script: https://github.com/ess-dmsc-dram/dmsc-school-notebooks/pull/16