### PR TITLE
Add scitacean dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ scipp
 scippneutron
 scippnexus
 scipy
+scitacean[sftp]
 sphinxcontrib-mermaid
 tqdm


### PR DESCRIPTION
This fixes the error about `ModuleNotFoundError: No module named 'scitacean'`, but new errors appear.

Not sure if they should be fixed or if the notebook is not meant to be built (see #69)

Any ideas @nitrosx @jl-wynen ?