### PR TITLE
Correct use of unavailable function -> available function

### DIFF
--- a/3-mcstas/Talk.ipynb
+++ b/3-mcstas/Talk.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "monte_carlo.ray_tracing_interactive(square_side_length=1.1)"
+    "monte_carlo.example_interactive(square_side_length=1.1)"
    ]
   },
   {


### PR DESCRIPTION
Talk.ipynb used a function which was not in `monte_carlo.py`, hence correcting

`monte_carlo.ray_tracing_interactive` -> `monte_carlo.example_interactive`

(Candidate fix for task 3 in https://github.com/ess-dmsc-dram/dmsc-school/issues/64)