### PR TITLE
Do not execute mcstas Talk notebook

### DIFF
--- a/4-reduction/qens-reduction.ipynb
+++ b/4-reduction/qens-reduction.ipynb
@@ -860,13 +860,15 @@
    },
    "outputs": [],
    "source": [
+    "from scippneutron.io import save_xye\n",
+    "\n",
     "for name, result in results.items():\n",
     "    # The simple file format does not support bin-edge coordinates.\n",
     "    # So we convert to bin-centers first.\n",
     "    data = result.copy()\n",
     "    data.coords[\"energy_transfer\"] = sc.midpoints(data.coords[\"energy_transfer\"])\n",
     "\n",
-    "    scn.io.save_xye(f\"qens_energy_transfer_{name}.dat\", data)"
+    "    save_xye(f\"qens_energy_transfer_{name}.dat\", data)"
    ]
   },
   {
@@ -1149,7 +1151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/_config.yml
+++ b/_config.yml
@@ -14,9 +14,9 @@ execute:
   allow_errors: false
   stderr_output: "error"
   exclude_patterns:
-    - '3-mcstas/Talk'
-    - '6-scicat/9-exercise'
-    - '6-scicat/notebooks/'
+    - '3-mcstas/Talk.ipynb'
+    - '6-scicat/9-exercise.ipynb'
+    - '6-scicat/notebooks/*'
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ execute:
   allow_errors: false
   stderr_output: "error"
   exclude_patterns:
+    - '3-mcstas/Talk'
     - '6-scicat/9-exercise'
     - '6-scicat/notebooks/'
 


### PR DESCRIPTION
Exclude the mcstas `Talk.ipynb` notebook from execution.
Also exclude the scicat notebooks which were also being run.

Also fix error in qens notebook with `save_xye`.