### PR TITLE
Fixes from the Sans dry run

### DIFF
--- a/3-mcstas/Exercise_SANS.ipynb
+++ b/3-mcstas/Exercise_SANS.ipynb
@@ -9,10 +9,7 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": [
-     "solution",
-     "hide-cell"
-    ]
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -47,8 +44,7 @@
      "slide_type": ""
     },
     "tags": [
-     "solution",
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],

--- a/4-reduction/qens-reduction.ipynb
+++ b/4-reduction/qens-reduction.ipynb
@@ -278,7 +278,7 @@
    },
    "outputs": [],
    "source": [
-    "binned_for_mask.hist().plot()"
+    "binned_for_mask.hist().plot(vmin=1)"
    ]
   },
   {

--- a/4-reduction/sans-reduction.ipynb
+++ b/4-reduction/sans-reduction.ipynb
@@ -354,6 +354,11 @@
     "\n",
     "\n",
     "graph[\"Q\"] = compute_q\n",
+    "\n",
+    "# Show the updated graph\n",
+    "display(sc.show_graph(graph, simplified=True))\n",
+    "\n",
+    "# Run the coordinate transformation\n",
     "sample_q = sample.transform_coords(\"Q\", graph=graph)\n",
     "sample_q"
    ]
@@ -977,7 +982,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/4-reduction/sans-reduction.ipynb
+++ b/4-reduction/sans-reduction.ipynb
@@ -520,6 +520,8 @@
     "tags": []
    },
    "source": [
+    "**Bonus question:** can you explain why the counts in the flat-field data drop at high $Q$?\n",
+    "\n",
     "## Exercise 3: Normalize the sample run\n",
     "\n",
     "The flat-field run is giving a measure of the efficiency of each detector pixel.\n",

--- a/5-analysis/load.py
+++ b/5-analysis/load.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Tuple
+import numpy as np
+
+
+def load(filename: str) -> Tuple[np.ndarray, ...]:
+    """
+    Load data from a file. Filter out any NaN values.
+    """
+    x, y, e = np.loadtxt(filename, unpack=True)
+    sel = np.isfinite(y)
+    return x[sel], y[sel], e[sel]

--- a/5-analysis/qens.ipynb
+++ b/5-analysis/qens.ipynb
@@ -30,8 +30,9 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "from load import load\n",
     "\n",
-    "qens_data = np.loadtxt('../4-reduction/qens_energy_transfer_unknown_quasi_elastic_3_pulse.dat', unpack=True)"
+    "q, i, di = load('../4-reduction/qens_energy_transfer_unknown_quasi_elastic_3_pulse.dat')"
    ]
   },
   {
@@ -61,7 +62,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.errorbar(*qens_data)\n",
+    "plt.errorbar(q, i, di)\n",
     "plt.xlabel('$\\omega$/meV')\n",
     "plt.ylabel('$I(\\omega)$')\n",
     "plt.show()"
@@ -93,7 +94,8 @@
    },
    "outputs": [],
    "source": [
-    "q, i, di = qens_data[:, np.where((qens_data[0] > -0.06) & (qens_data[0] < 0.06))[0]]"
+    "sel = (q > -0.06) & (q < 0.06)\n",
+    "q, i, di = q[sel], i[sel], di[sel]"
    ]
   },
   {

--- a/5-analysis/sans.ipynb
+++ b/5-analysis/sans.ipynb
@@ -214,7 +214,7 @@
    "source": [
     "from easyscience.Objects.new_variable import Parameter\n",
     "\n",
-    "scale = Parameter(name='scale', value=1.4e-7, fixed=True)\n",
+    "scale = Parameter(name='scale', value=1.4e-7, fixed=False)\n",
     "delta_rho = Parameter(name='delta_rho', value=3, fixed=False, min=0, max=10)\n",
     "r = Parameter(name='r', value=80, fixed=False, min=0, max=1000)\n",
     "bkg = Parameter(name='bkg', value=0.01, fixed=False, min=0.001, max=0.1)"

--- a/5-analysis/sans.ipynb
+++ b/5-analysis/sans.ipynb
@@ -30,8 +30,9 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "from load import load\n",
     "\n",
-    "q, i, di = np.loadtxt('../4-reduction/sans_iofq_3pulses.dat', unpack=True)"
+    "q, i, di = load('../4-reduction/sans_iofq_3pulses.dat')"
    ]
   },
   {


### PR DESCRIPTION
- fix tags in SANS McStas notebook
- add `vmin=1` in plot for QENS masked data in reduction
- add an extra `show_graph` in SANS reduction after Q was added to graph
- add bonus question about flat-field data dropping at high Q in SANS reduction
- add loader for data analysis that filters nans
- change `fixed` to `False` in SANS analysis