### PR TITLE
Exclude venv folders

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,5 +49,7 @@ sphinx:
 
 exclude_patterns:
   - 'article/article.md'
+  - '.venv'
+  - 'venv'
 
 only_build_toc_files: true


### PR DESCRIPTION
Fixes #97

The build actually passes(*) but raises a lot of warnings. This PR excludes the most typical virtual env folders because we don't actually want to include them in the book.

(*): Once #93 and #96 are fixed.