### PR TITLE
Set up actionlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,7 @@ repos:
     rev: v1.24.3
     hooks:
       - id: typos
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
Motivated by the AI suggestions in #105, this PR sets up actionlint as a pre-commit hook. This should be more reliable than an LLM.