### PR TITLE
Git ignore more mcstas and data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ _build
 *.csv
 *.h5
 *.nxs
+*.tar.gz
 __pycache__/
 .idea

--- a/3-mcstas/.gitignore
+++ b/3-mcstas/.gitignore
@@ -1,3 +1,6 @@
 # Generated files by McStas
 *.instr
 *_db
+*.c
+*.sim
+*.out


### PR DESCRIPTION
Now that we store outputs of McStas directly in the `3-mcstas` folder, we have a lot more files that should be ignored by git.