### PR TITLE
Add smoothing and xye header in reduction notebook

### DIFF
--- a/4-reduction/reduction-powder.ipynb
+++ b/4-reduction/reduction-powder.ipynb
@@ -556,9 +556,35 @@
    "outputs": [],
    "source": [
     "num = better_dspacing.hist(two_theta=120, dspacing=dbins)\n",
-    "den = van_dspacing.hist(two_theta=num.coords['two_theta'], dspacing=dbins)\n",
+    "den = van_dspacing.hist(two_theta=num.coords['two_theta'], dspacing=dbins)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a3e1488-af6f-4d67-b074-04960f39fc74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Smooth the Vanadium run \n",
+    "from scipp.scipy.ndimage import gaussian_filter\n",
+    "smooth_vana = gaussian_filter(sc.values(den.sum('two_theta')), sigma=10)\n",
     "\n",
-    "normed = (num.sum('two_theta') / den.sum('two_theta'))\n",
+    "pp.plot({'orig': den.sum('two_theta'), \n",
+    "         'smooth': smooth_vana}, \n",
+    "        title='Vanadium - smoothed')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7541a064-3bbd-4d9f-8b08-9e914d55ac8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# normed = (num.sum('two_theta') / den.sum('two_theta'))\n",
+    "normed = (num.sum('two_theta') / smooth_vana)\n",
+    "\n",
     "normed.plot()"
    ]
   },
@@ -587,7 +613,8 @@
     "    * sc.sin(0.5 * average_two_theta),\n",
     "    unit='us / angstrom',\n",
     ")\n",
-    "difc"
+    "\n",
+    "average_l , sc.to_unit(average_two_theta, 'deg'), difc"
    ]
   },
   {
@@ -603,7 +630,7 @@
     "result_si.coords[\"tof\"] = (sc.midpoints(result_si.coords[\"dspacing\"]) * difc).to(unit='us')\n",
     "\n",
     "save_xye(\"powder_reduced_Si.xye\", result_si.rename_dims(dspacing='tof'),\n",
-    "         header=f\"DIFC = {difc.to(unit='us/angstrom').value} [µ/Å]\\ntof [µs]               Y [counts]               E [counts]\")"
+    "         header=f\"DIFC = {difc.to(unit='us/angstrom').value} [µ/Å] L = {average_l.value} [m] two_theta = {sc.to_unit(average_two_theta, 'deg').value} [deg]\\ntof [µs]               Y [counts]               E [counts]\")"
    ]
   },
   {
@@ -621,7 +648,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "folder = \"../3-mcstas/powder_sample_2\"\n",
+    "folder = \"../3-mcstas/powder_sample_2\"   # or \"../3-mcstas/powder_sample_3\"\n",
     "\n",
     "unknown = utils.load_powder(folder)\n",
     "\n",
@@ -635,8 +662,31 @@
     "\n",
     "# Normalize\n",
     "unknown_num = unknown_dspacing.hist(two_theta=den.coords['two_theta'], dspacing=dbins)\n",
-    "unknown_normed = (unknown_num.sum('two_theta') / den.sum('two_theta'))\n",
+    "\n",
+    "# unknown_normed = (unknown_num.sum('two_theta') / den.sum('two_theta'))\n",
+    "unknown_normed = (unknown_num.sum('two_theta') / smooth_vana)\n",
+    "\n",
     "unknown_normed.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "322f537a-efe9-43e9-bbf5-cefe64d12150",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "average_l = unknown_dspacing.coords[\"Ltotal\"].mean()\n",
+    "average_two_theta = unknown_dspacing.coords[\"two_theta\"].mean()\n",
+    "difc = sc.to_unit(\n",
+    "    2\n",
+    "    * sc.constants.m_n\n",
+    "    / sc.constants.h\n",
+    "    * average_l\n",
+    "    * sc.sin(0.5 * average_two_theta),\n",
+    "    unit='us / angstrom',\n",
+    ")\n",
+    "average_l , sc.to_unit(average_two_theta, 'deg'), difc"
    ]
   },
   {
@@ -658,7 +708,7 @@
     "result_unknown.coords[\"tof\"] = (sc.midpoints(result_unknown.coords[\"dspacing\"]) * difc).to(unit='us')\n",
     "\n",
     "save_xye(\"powder_reduced_unknown.xye\", result_unknown.rename_dims(dspacing='tof'),\n",
-    "         header=f\"DIFC = {difc.to(unit='us/angstrom').value} [µ/Å]\\ntof [µs]               Y [counts]               E [counts]\")"
+    "         header=f\"DIFC = {difc.to(unit='us/angstrom').value} [µ/Å] L = {average_l.value} [m] two_theta = {sc.to_unit(average_two_theta, 'deg').value} [deg]\\ntof [µs]               Y [counts]               E [counts]\")"
    ]
   }
  ],
@@ -678,7 +728,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update reduction notebook with 
- unknown sample 3 (lbco instead of ncalf), 
- smoothing of vanadium
- header of xye file with metadata required for analysis