### PR TITLE
Switches to PyPI EasyDiffraction and updates notebook

### DIFF
--- a/5-analysis/analysis-powder-diffraction.ipynb
+++ b/5-analysis/analysis-powder-diffraction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "60194511",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Fitting Powder Diffraction data\n",
@@ -21,7 +21,7 @@
     "This tutorial is self-contained and designed for hands-on learning.\n",
     "However, if you're interested in exploring more advanced features or learning\n",
     "about additional capabilities of the EasyDiffraction library, please refer to\n",
-    "the official documentation: https://easyscience.github.io/diffraction-lib\n",
+    "the official documentation: https://docs.easydiffraction.org/lib/tutorials/\n",
     "\n",
     "Depending on your requirements, you may choose to import only specific\n",
     "classes. However, for the sake of simplicity in this tutorial, we will import\n",
@@ -30,17 +30,17 @@
   },
   {
    "cell_type": "code",
-   "id": "ec0e8dc6",
+   "execution_count": null,
+   "id": "1",
    "metadata": {},
+   "outputs": [],
    "source": [
     "import easydiffraction as ed"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "37c36d31",
+   "id": "2",
    "metadata": {},
    "source": [
     "## 📘 Introduction: Simple Reference Fit – Si\n",
@@ -67,17 +67,17 @@
   },
   {
    "cell_type": "code",
-   "id": "4164e1d9",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
-   "source": [
-    "project_1 = ed.Project(name=\"reference\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1 = ed.Project(name='reference')"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "0d6eb80f",
+   "id": "4",
    "metadata": {},
    "source": [
     "\n",
@@ -89,18 +89,19 @@
   },
   {
    "cell_type": "code",
-   "id": "656b2e32",
+   "execution_count": null,
+   "id": "5",
    "metadata": {},
-   "source": [
-    "project_1.info.title = \"Reference Silicon Fit\"\n",
-    "project_1.info.description = \"Fitting simulated powder diffraction pattern of Si.\""
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.info.title = 'Reference Silicon Fit'\n",
+    "project_1.info.description = 'Fitting simulated powder diffraction pattern of Si.'"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
    "source": [
     "### 🔬 Create an Experiment\n",
     "\n",
@@ -111,37 +112,72 @@
     "\n",
     "In this case, the experiment is defined as a powder diffraction measurement\n",
     "using time-of-flight neutrons. The measured data is loaded from a file\n",
-    "containing the reduced diffraction pattern of Si from the data reduction tutorial."
-   ],
-   "id": "a326b89c"
+    "containing the reduced diffraction pattern of Si from the data reduction\n",
+    "tutorial."
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "source": "si_xye_path = \"../4-reduction/reduced_Si.xye\"",
-   "id": "69a3829e40bd81e5",
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "si_xye_path = '../4-reduction/reduced_Si.xye'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "Use the following cell if your data reduction failed and the reduced data\n",
+    "file is missing. In this case, you can download our pre-generated reduced\n",
+    "data file from the EasyDiffraction repository.\n",
+    "\n",
+    "The `download_from_repository` function will not overwrite an existing file\n",
+    "unless you set `overwrite=True`, so it's safe to run even if the file is\n",
+    "already present."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ed.download_from_repository('reduced_Si.xye', destination='../4-reduction')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "Now we can create the experiment and load the measured data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "project_1.experiments.add(\n",
-    "    name=\"sim_si\",\n",
-    "    sample_form=\"powder\",\n",
-    "    beam_mode=\"time-of-flight\",\n",
-    "    radiation_probe=\"neutron\",\n",
+    "    name='sim_si',\n",
+    "    sample_form='powder',\n",
+    "    beam_mode='time-of-flight',\n",
+    "    radiation_probe='neutron',\n",
     "    data_path=si_xye_path,\n",
     ")"
-   ],
-   "id": "d7aa9526"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
    "source": [
     "#### Inspect Measured Data\n",
     "\n",
@@ -158,28 +194,32 @@
     "\n",
     "Before plotting, we set the plotting engine to 'plotly', which provides\n",
     "interactive visualizations."
-   ],
-   "id": "c6939180"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_1.plotter.engine = \"plotly\"",
-   "id": "ad96437f"
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_1.plotter.engine = 'plotly'"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_1.plot_meas(expt_name=\"sim_si\")",
-   "id": "bb89e799"
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_1.plot_meas(expt_name='sim_si')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
    "source": [
     "If you zoom in on the highest TOF peak (around 120,000 μs), you will notice\n",
     "that it has a broad and unusual shape. This distortion, along with some more\n",
@@ -188,41 +228,43 @@
     "advanced data reduction, which is beyond the scope of this tutorial.\n",
     "Therefore, we will simply exclude both the low and high TOF regions from the\n",
     "analysis by adding an excluded regions to the experiment."
-   ],
-   "id": "1b130688"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_1.experiments[\"sim_si\"].excluded_regions.add(minimum=0, maximum=55000)\n",
-    "project_1.experiments[\"sim_si\"].excluded_regions.add(minimum=105500, maximum=200000)"
-   ],
-   "id": "61862088"
+    "project_1.experiments['sim_si'].excluded_regions.add(minimum=0, maximum=55000)\n",
+    "project_1.experiments['sim_si'].excluded_regions.add(minimum=105500, maximum=200000)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
    "source": [
     "To visualize the effect of excluding the high TOF region, we can plot\n",
     "the measured data again. The excluded region will be omitted from the plot\n",
     "and is not used in the fitting process."
-   ],
-   "id": "6ff6d8f6"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_1.plot_meas(expt_name=\"sim_si\")",
-   "id": "7bcfd1d2"
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_1.plot_meas(expt_name='sim_si')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
    "source": [
     "#### Set Instrument Parameters\n",
     "\n",
@@ -239,47 +281,45 @@
     "\n",
     "You can set them manually, but it is more convenient to use the\n",
     "`get_value_from_xye_header` function from the EasyDiffraction library."
-   ],
-   "id": "779a4569"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_1.experiments[\"sim_si\"].instrument.setup_twotheta_bank = ed.get_value_from_xye_header(\n",
-    "    si_xye_path, \"two_theta\"\n",
-    ")\n",
-    "project_1.experiments[\"sim_si\"].instrument.calib_d_to_tof_linear = ed.get_value_from_xye_header(\n",
-    "    si_xye_path, \"DIFC\"\n",
-    ")"
-   ],
-   "id": "1dda5bf0"
+    "project_1.experiments['sim_si'].instrument.setup_twotheta_bank = ed.get_value_from_xye_header(si_xye_path, 'two_theta')\n",
+    "project_1.experiments['sim_si'].instrument.calib_d_to_tof_linear = ed.get_value_from_xye_header(si_xye_path, 'DIFC')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
    "source": [
     "Every parameters is an object, which has different attributes, such as\n",
     "`value`, `free`, etc. To display the parameter of interest, you can simply\n",
     "print the parameter object. For example, to display the linear conversion\n",
     "factor from d-spacing to TOF, which is the `calib_d_to_tof_linear` parameter,\n",
     "you can use the following code:"
-   ],
-   "id": "b2a25264d554b384"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "print(project_1.experiments[\"sim_si\"].instrument.calib_d_to_tof_linear)",
-   "id": "7895790f4fe85466"
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(project_1.experiments['sim_si'].instrument.calib_d_to_tof_linear)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
    "source": [
     "The `value` attribute represents the current value of the parameter as a float.\n",
     "You can access it directly by using the `value` attribute of the parameter.\n",
@@ -287,29 +327,31 @@
     "when you want to assign it to another parameter. For example, to get only the\n",
     "value of the same parameter as floating point number, but not the whole object,\n",
     "you can do the following:"
-   ],
-   "id": "47263acd1a91e91f"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "print(project_1.experiments[\"sim_si\"].instrument.calib_d_to_tof_linear.value)",
-   "id": "ee7497780ca88a7e"
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(project_1.experiments['sim_si'].instrument.calib_d_to_tof_linear.value)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
    "source": [
     "Note that to set the value of the parameter, you can simply assign a new value\n",
     "to the parameter object without using the `value` attribute, as we did above."
-   ],
-   "id": "7c8baeb24300913a"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "26",
+   "metadata": {},
    "source": [
     "#### Set Peak Profile Parameters\n",
     "\n",
@@ -325,31 +367,31 @@
     "of a standard sample. We consider this Si sample as a standard reference.\n",
     "Therefore, we will set the initial values of the peak profile parameters based\n",
     "on the values obtained from another simulation and refine them during the\n",
-    "fitting process. The refined parameters will be used as a starting point for the\n",
-    "more complex fit in the next part of the tutorial."
-   ],
-   "id": "8669fd57"
+    "fitting process. The refined parameters will be used as a starting point for\n",
+    "the more complex fit in the next part of the tutorial."
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_1.experiments[\"sim_si\"].peak_profile_type = \"pseudo-voigt * ikeda-carpenter\"\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_0 = 69498\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_1 = -55578\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_2 = 14560\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_mix_beta_0 = 0.0019\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_mix_beta_1 = 0.0137\n",
-    "project_1.experiments[\"sim_si\"].peak.asym_alpha_0 = -0.0055\n",
-    "project_1.experiments[\"sim_si\"].peak.asym_alpha_1 = 0.0147"
-   ],
-   "id": "8dbc7188"
+    "project_1.experiments['sim_si'].peak_profile_type = 'pseudo-voigt * ikeda-carpenter'\n",
+    "project_1.experiments['sim_si'].peak.broad_gauss_sigma_0 = 69498\n",
+    "project_1.experiments['sim_si'].peak.broad_gauss_sigma_1 = -55578\n",
+    "project_1.experiments['sim_si'].peak.broad_gauss_sigma_2 = 14560\n",
+    "project_1.experiments['sim_si'].peak.broad_mix_beta_0 = 0.0019\n",
+    "project_1.experiments['sim_si'].peak.broad_mix_beta_1 = 0.0137\n",
+    "project_1.experiments['sim_si'].peak.asym_alpha_0 = -0.0055\n",
+    "project_1.experiments['sim_si'].peak.asym_alpha_1 = 0.0147"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "28",
+   "metadata": {},
    "source": [
     "#### Set Background\n",
     "\n",
@@ -377,29 +419,28 @@
     "Let's set all the background points at a constant value of 0.01, which can be\n",
     "roughly determined by the eye, and we will refine them later during the fitting\n",
     "process."
-   ],
-   "id": "078f95cc"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "29",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_1.experiments[\"sim_si\"].background_type = \"line-segment\"\n",
-    "project_1.experiments[\"sim_si\"].background.add(x=50000, y=0.01)\n",
-    "project_1.experiments[\"sim_si\"].background.add(x=60000, y=0.01)\n",
-    "project_1.experiments[\"sim_si\"].background.add(x=70000, y=0.01)\n",
-    "project_1.experiments[\"sim_si\"].background.add(x=80000, y=0.01)\n",
-    "project_1.experiments[\"sim_si\"].background.add(x=90000, y=0.01)\n",
-    "project_1.experiments[\"sim_si\"].background.add(x=100000, y=0.01)\n",
-    "project_1.experiments[\"sim_si\"].background.add(x=110000, y=0.01)"
-   ],
-   "id": "a3b802aa"
+    "project_1.experiments['sim_si'].background_type = 'line-segment'\n",
+    "project_1.experiments['sim_si'].background.add(x=50000, y=0.01)\n",
+    "project_1.experiments['sim_si'].background.add(x=60000, y=0.01)\n",
+    "project_1.experiments['sim_si'].background.add(x=70000, y=0.01)\n",
+    "project_1.experiments['sim_si'].background.add(x=80000, y=0.01)\n",
+    "project_1.experiments['sim_si'].background.add(x=90000, y=0.01)\n",
+    "project_1.experiments['sim_si'].background.add(x=100000, y=0.01)\n",
+    "project_1.experiments['sim_si'].background.add(x=110000, y=0.01)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "77fae341",
+   "id": "30",
    "metadata": {},
    "source": [
     "### 🧩 Create a Sample Model – Si\n",
@@ -441,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b897365b",
+   "id": "31",
    "metadata": {},
    "source": [
     "```\n",
@@ -473,7 +514,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c36ee5a",
+   "id": "32",
    "metadata": {},
    "source": [
     "\n",
@@ -486,17 +527,17 @@
   },
   {
    "cell_type": "code",
-   "id": "e46d255a",
+   "execution_count": null,
+   "id": "33",
    "metadata": {},
-   "source": [
-    "project_1.sample_models.add(name=\"si\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.sample_models.add(name='si')"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "4c3ac1e6",
+   "id": "34",
    "metadata": {},
    "source": [
     "#### Set Space Group"
@@ -504,18 +545,18 @@
   },
   {
    "cell_type": "code",
-   "id": "ba69a031",
+   "execution_count": null,
+   "id": "35",
    "metadata": {},
-   "source": [
-    "project_1.sample_models[\"si\"].space_group.name_h_m = \"F d -3 m\"\n",
-    "project_1.sample_models[\"si\"].space_group.it_coordinate_system_code = \"2\""
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.sample_models['si'].space_group.name_h_m = 'F d -3 m'\n",
+    "project_1.sample_models['si'].space_group.it_coordinate_system_code = '2'"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "f6afea8d",
+   "id": "36",
    "metadata": {},
    "source": [
     "#### Set Lattice Parameters"
@@ -523,17 +564,17 @@
   },
   {
    "cell_type": "code",
-   "id": "0fc252e3",
+   "execution_count": null,
+   "id": "37",
    "metadata": {},
-   "source": [
-    "project_1.sample_models[\"si\"].cell.length_a = 5.43"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.sample_models['si'].cell.length_a = 5.43"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "54fc9101",
+   "id": "38",
    "metadata": {},
    "source": [
     "#### Set Atom Sites"
@@ -541,47 +582,48 @@
   },
   {
    "cell_type": "code",
-   "id": "325d5f49",
+   "execution_count": null,
+   "id": "39",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "project_1.sample_models[\"si\"].atom_sites.add(\n",
-    "    label=\"Si\",\n",
-    "    type_symbol=\"Si\",\n",
+    "project_1.sample_models['si'].atom_sites.add(\n",
+    "    label='Si',\n",
+    "    type_symbol='Si',\n",
     "    fract_x=0,\n",
     "    fract_y=0,\n",
     "    fract_z=0,\n",
-    "    wyckoff_letter=\"a\",\n",
+    "    wyckoff_letter='a',\n",
     "    b_iso=0.89,\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "33349f94",
+   "id": "40",
    "metadata": {},
    "source": [
     "### 🔗 Assign Sample Model to Experiment\n",
     "\n",
-    "Now we need to assign, or link, this sample model to the experiment created above.\n",
-    "This linked crystallographic phase will be used to calculate the expected diffraction\n",
-    "pattern based on the crystal structure defined in the sample model."
+    "Now we need to assign, or link, this sample model to the experiment created\n",
+    "above. This linked crystallographic phase will be used to calculate the\n",
+    "expected diffraction pattern based on the crystal structure defined in the\n",
+    "sample model."
    ]
   },
   {
    "cell_type": "code",
-   "id": "e47d6115",
+   "execution_count": null,
+   "id": "41",
    "metadata": {},
-   "source": [
-    "project_1.experiments[\"sim_si\"].linked_phases.add(id=\"si\", scale=1.0)"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.experiments['sim_si'].linked_phases.add(id='si', scale=1.0)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "ad28c299",
+   "id": "42",
    "metadata": {},
    "source": [
     "### 🚀 Analyze and Fit the Data\n",
@@ -612,28 +654,28 @@
   },
   {
    "cell_type": "code",
-   "id": "e0b4b651",
+   "execution_count": null,
+   "id": "43",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "project_1.experiments[\"sim_si\"].linked_phases[\"si\"].scale.free = True\n",
+    "project_1.experiments['sim_si'].linked_phases['si'].scale.free = True\n",
     "\n",
-    "for line_segment in project_1.experiments[\"sim_si\"].background:\n",
+    "for line_segment in project_1.experiments['sim_si'].background:\n",
     "    line_segment.y.free = True\n",
     "\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_0.free = True\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_1.free = True\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_2.free = True\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_mix_beta_0.free = True\n",
-    "project_1.experiments[\"sim_si\"].peak.broad_mix_beta_1.free = True\n",
-    "project_1.experiments[\"sim_si\"].peak.asym_alpha_0.free = True\n",
-    "project_1.experiments[\"sim_si\"].peak.asym_alpha_1.free = True"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "project_1.experiments['sim_si'].peak.broad_gauss_sigma_0.free = True\n",
+    "project_1.experiments['sim_si'].peak.broad_gauss_sigma_1.free = True\n",
+    "project_1.experiments['sim_si'].peak.broad_gauss_sigma_2.free = True\n",
+    "project_1.experiments['sim_si'].peak.broad_mix_beta_0.free = True\n",
+    "project_1.experiments['sim_si'].peak.broad_mix_beta_1.free = True\n",
+    "project_1.experiments['sim_si'].peak.asym_alpha_0.free = True\n",
+    "project_1.experiments['sim_si'].peak.asym_alpha_1.free = True"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "04ac3b70",
+   "id": "44",
    "metadata": {},
    "source": [
     "#### Show Free Parameters\n",
@@ -644,17 +686,17 @@
   },
   {
    "cell_type": "code",
-   "id": "11d464c3",
+   "execution_count": null,
+   "id": "45",
    "metadata": {},
+   "outputs": [],
    "source": [
     "project_1.analysis.show_free_params()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "637fb4b6",
+   "id": "46",
    "metadata": {},
    "source": [
     "#### Visualize Diffraction Patterns\n",
@@ -669,15 +711,17 @@
   },
   {
    "cell_type": "code",
-   "id": "37089fac",
+   "execution_count": null,
+   "id": "47",
    "metadata": {},
-   "source": "project_1.plot_meas_vs_calc(expt_name=\"sim_si\")",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.plot_meas_vs_calc(expt_name='sim_si')"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "4c669678",
+   "id": "48",
    "metadata": {},
    "source": [
     "#### Run Fitting\n",
@@ -688,17 +732,17 @@
   },
   {
    "cell_type": "code",
-   "id": "26fea591",
+   "execution_count": null,
+   "id": "49",
    "metadata": {},
+   "outputs": [],
    "source": [
     "project_1.analysis.fit()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "0128aea9",
+   "id": "50",
    "metadata": {},
    "source": [
     "#### Check Fit Results\n",
@@ -716,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6b10e3a",
+   "id": "51",
    "metadata": {},
    "source": [
     "#### Visualize Fit Results\n",
@@ -729,17 +773,17 @@
   },
   {
    "cell_type": "code",
-   "id": "dbd9d48f",
+   "execution_count": null,
+   "id": "52",
    "metadata": {},
-   "source": [
-    "project_1.plot_meas_vs_calc(expt_name=\"sim_si\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.plot_meas_vs_calc(expt_name='sim_si')"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "3728cc3d",
+   "id": "53",
    "metadata": {},
    "source": [
     "#### TOF vs d-spacing\n",
@@ -757,17 +801,17 @@
   },
   {
    "cell_type": "code",
-   "id": "ba29f44a",
+   "execution_count": null,
+   "id": "54",
    "metadata": {},
-   "source": [
-    "project_1.plot_meas_vs_calc(expt_name=\"sim_si\", d_spacing=True)"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.plot_meas_vs_calc(expt_name='sim_si', d_spacing=True)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "372cfac2",
+   "id": "55",
    "metadata": {},
    "source": [
     "As you can see, the calculated diffraction pattern now matches the measured\n",
@@ -801,21 +845,19 @@
   },
   {
    "cell_type": "code",
-   "id": "c9ac219f",
+   "execution_count": null,
+   "id": "56",
    "metadata": {},
-   "source": [
-    "project_2 = ed.Project(name=\"main\")\n",
-    "project_2.info.title = \"La0.5Ba0.5CoO3 Fit\"\n",
-    "project_2.info.description = (\n",
-    "    \"Fitting simulated powder diffraction pattern of La0.5Ba0.5CoO3.\"\n",
-    ")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2 = ed.Project(name='main')\n",
+    "project_2.info.title = 'La0.5Ba0.5CoO3 Fit'\n",
+    "project_2.info.description = 'Fitting simulated powder diffraction pattern of La0.5Ba0.5CoO3.'"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "9db79f04",
+   "id": "57",
    "metadata": {},
    "source": [
     "### 🔬 Exercise 2: Define an Experiment\n",
@@ -832,32 +874,45 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "58",
+   "metadata": {},
    "outputs": [],
-   "source": "lbco_xye_path = \"../4-reduction/reduced_LBCO.xye\"",
-   "id": "9390d21130be895",
-   "execution_count": null
+   "source": [
+    "lbco_xye_path = '../4-reduction/reduced_LBCO.xye'"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ed.download_from_repository('reduced_LBCO.xye', destination='../4-reduction')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "project_2.experiments.add(\n",
-    "    name=\"sim_lbco\",\n",
-    "    sample_form=\"powder\",\n",
-    "    beam_mode=\"time-of-flight\",\n",
-    "    radiation_probe=\"neutron\",\n",
+    "    name='sim_lbco',\n",
+    "    sample_form='powder',\n",
+    "    beam_mode='time-of-flight',\n",
+    "    radiation_probe='neutron',\n",
     "    data_path=lbco_xye_path,\n",
     ")"
-   ],
-   "id": "18359b79"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "61",
+   "metadata": {},
    "source": [
     "#### Exercise 2.1: Inspect Measured Data\n",
     "\n",
@@ -871,42 +926,44 @@
     "in the previous part of the tutorial.\n",
     "\n",
     "**Solution:**"
-   ],
-   "id": "a6d13779"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "62",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.plotter.engine = \"plotly\"\n",
-    "project_2.plot_meas(expt_name=\"sim_lbco\")"
-   ],
-   "id": "d5798e4b"
+    "project_2.plotter.engine = 'plotly'\n",
+    "project_2.plot_meas(expt_name='sim_lbco')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "63",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.experiments[\"sim_lbco\"].excluded_regions.add(minimum=0, maximum=55000)\n",
-    "project_2.experiments[\"sim_lbco\"].excluded_regions.add(minimum=105500, maximum=200000)"
-   ],
-   "id": "2a2dcb68"
+    "project_2.experiments['sim_lbco'].excluded_regions.add(minimum=0, maximum=55000)\n",
+    "project_2.experiments['sim_lbco'].excluded_regions.add(minimum=105500, maximum=200000)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_2.plot_meas(expt_name=\"sim_lbco\")",
-   "id": "95ba2cb8"
+   "id": "64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_2.plot_meas(expt_name='sim_lbco')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "65",
+   "metadata": {},
    "source": [
     "#### Exercise 2.2: Set Instrument Parameters\n",
     "\n",
@@ -916,27 +973,23 @@
     "follow the same approach as in the previous part of the tutorial.\n",
     "\n",
     "**Solution:**"
-   ],
-   "id": "c4078a0d"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "66",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.experiments[\"sim_lbco\"].instrument.setup_twotheta_bank = ed.get_value_from_xye_header(\n",
-    "    lbco_xye_path, \"two_theta\"\n",
-    ")\n",
-    "project_2.experiments[\"sim_lbco\"].instrument.calib_d_to_tof_linear = ed.get_value_from_xye_header(\n",
-    "    lbco_xye_path, \"DIFC\"\n",
-    ")"
-   ],
-   "id": "af03ff64"
+    "project_2.experiments['sim_lbco'].instrument.setup_twotheta_bank = ed.get_value_from_xye_header(lbco_xye_path, 'two_theta')\n",
+    "project_2.experiments['sim_lbco'].instrument.calib_d_to_tof_linear = ed.get_value_from_xye_header(lbco_xye_path, 'DIFC')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "67",
+   "metadata": {},
    "source": [
     "#### Exercise 2.3: Set Peak Profile Parameters\n",
     "\n",
@@ -948,29 +1001,29 @@
     "experiment. This will help us to have a good starting point for the fit.\n",
     "\n",
     "**Solution:**"
-   ],
-   "id": "17de2311"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "68",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.peak_profile_type = \"pseudo-voigt * ikeda-carpenter\"\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_gauss_sigma_0 = project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_0.value\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_gauss_sigma_1 = project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_1.value\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_gauss_sigma_2 = project_1.experiments[\"sim_si\"].peak.broad_gauss_sigma_2.value\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_mix_beta_0 = project_1.experiments[\"sim_si\"].peak.broad_mix_beta_0.value\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_mix_beta_1 = project_1.experiments[\"sim_si\"].peak.broad_mix_beta_1.value\n",
-    "project_2.experiments[\"sim_lbco\"].peak.asym_alpha_0 = project_1.experiments[\"sim_si\"].peak.asym_alpha_0.value\n",
-    "project_2.experiments[\"sim_lbco\"].peak.asym_alpha_1 = project_1.experiments[\"sim_si\"].peak.asym_alpha_1.value"
-   ],
-   "id": "6c5c978d"
+    "project_2.peak_profile_type = 'pseudo-voigt * ikeda-carpenter'\n",
+    "project_2.experiments['sim_lbco'].peak.broad_gauss_sigma_0 = project_1.experiments['sim_si'].peak.broad_gauss_sigma_0.value\n",
+    "project_2.experiments['sim_lbco'].peak.broad_gauss_sigma_1 = project_1.experiments['sim_si'].peak.broad_gauss_sigma_1.value\n",
+    "project_2.experiments['sim_lbco'].peak.broad_gauss_sigma_2 = project_1.experiments['sim_si'].peak.broad_gauss_sigma_2.value\n",
+    "project_2.experiments['sim_lbco'].peak.broad_mix_beta_0 = project_1.experiments['sim_si'].peak.broad_mix_beta_0.value\n",
+    "project_2.experiments['sim_lbco'].peak.broad_mix_beta_1 = project_1.experiments['sim_si'].peak.broad_mix_beta_1.value\n",
+    "project_2.experiments['sim_lbco'].peak.asym_alpha_0 = project_1.experiments['sim_si'].peak.asym_alpha_0.value\n",
+    "project_2.experiments['sim_lbco'].peak.asym_alpha_1 = project_1.experiments['sim_si'].peak.asym_alpha_1.value"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "69",
+   "metadata": {},
    "source": [
     "#### Exercise 2.4: Set Background\n",
     "\n",
@@ -983,29 +1036,29 @@
     "background level.\n",
     "\n",
     "**Solution:**"
-   ],
-   "id": "a8384726"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "70",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.experiments[\"sim_lbco\"].background_type = \"line-segment\"\n",
-    "project_2.experiments[\"sim_lbco\"].background.add(x=50000, y=0.2)\n",
-    "project_2.experiments[\"sim_lbco\"].background.add(x=60000, y=0.2)\n",
-    "project_2.experiments[\"sim_lbco\"].background.add(x=70000, y=0.2)\n",
-    "project_2.experiments[\"sim_lbco\"].background.add(x=80000, y=0.2)\n",
-    "project_2.experiments[\"sim_lbco\"].background.add(x=90000, y=0.2)\n",
-    "project_2.experiments[\"sim_lbco\"].background.add(x=100000, y=0.2)\n",
-    "project_2.experiments[\"sim_lbco\"].background.add(x=110000, y=0.2)"
-   ],
-   "id": "72899511"
+    "project_2.experiments['sim_lbco'].background_type = 'line-segment'\n",
+    "project_2.experiments['sim_lbco'].background.add(x=50000, y=0.2)\n",
+    "project_2.experiments['sim_lbco'].background.add(x=60000, y=0.2)\n",
+    "project_2.experiments['sim_lbco'].background.add(x=70000, y=0.2)\n",
+    "project_2.experiments['sim_lbco'].background.add(x=80000, y=0.2)\n",
+    "project_2.experiments['sim_lbco'].background.add(x=90000, y=0.2)\n",
+    "project_2.experiments['sim_lbco'].background.add(x=100000, y=0.2)\n",
+    "project_2.experiments['sim_lbco'].background.add(x=110000, y=0.2)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "71",
+   "metadata": {},
    "source": [
     "### 🧩 Exercise 3: Define a Sample Model – LBCO\n",
     "\n",
@@ -1016,12 +1069,12 @@
     "Note that those parameters are not necessarily the most accurate ones, but they\n",
     "are a good starting point for the fit. The aim of the study is to refine the\n",
     "LBCO lattice parameters."
-   ],
-   "id": "bc3338fd"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "72",
+   "metadata": {},
    "source": [
     "```\n",
     "data_lbco\n",
@@ -1051,12 +1104,12 @@
     "Co Co   0.5 0.5 0.5   b   1.0   Biso 0.80\n",
     "O  O    0.0 0.5 0.5   c   1.0   Biso 1.66\n",
     "```"
-   ],
-   "id": "f9a2183d"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "73",
+   "metadata": {},
    "source": [
     "#### Exercise 3.1: Create Sample Model\n",
     "\n",
@@ -1066,20 +1119,22 @@
     "tutorial, but this time you need to create a sample model for LBCO.\n",
     "\n",
     "**Solution:**"
-   ],
-   "id": "cea5b06e"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_2.sample_models.add(name=\"lbco\")",
-   "id": "d14df9ce"
+   "id": "74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_2.sample_models.add(name='lbco')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "75",
+   "metadata": {},
    "source": [
     "#### Exercise 3.2: Set Space Group\n",
     "\n",
@@ -1088,23 +1143,22 @@
     "**Hint:** Use the space group name and IT coordinate system code from the CIF data.\n",
     "\n",
     "**Solution:**"
-   ],
-   "id": "76ca4888"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "76",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.sample_models[\"lbco\"].space_group.name_h_m = \"P m -3 m\"\n",
-    "project_2.sample_models[\"lbco\"].space_group.it_coordinate_system_code = \"1\""
-   ],
-   "id": "76e256b3"
+    "project_2.sample_models['lbco'].space_group.name_h_m = 'P m -3 m'\n",
+    "project_2.sample_models['lbco'].space_group.it_coordinate_system_code = '1'"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "140fb92a",
+   "id": "77",
    "metadata": {},
    "source": [
     "#### Exercise 3.3: Set Lattice Parameters\n",
@@ -1118,17 +1172,17 @@
   },
   {
    "cell_type": "code",
-   "id": "b2fee473",
+   "execution_count": null,
+   "id": "78",
    "metadata": {},
-   "source": [
-    "project_2.sample_models[\"lbco\"].cell.length_a = 3.88"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.sample_models['lbco'].cell.length_a = 3.88"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "16094c3b",
+   "id": "79",
    "metadata": {},
    "source": [
     "#### Exercise 3.4: Set Atom Sites\n",
@@ -1144,54 +1198,54 @@
   },
   {
    "cell_type": "code",
-   "id": "f4c6a3fd",
+   "execution_count": null,
+   "id": "80",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.sample_models[\"lbco\"].atom_sites.add(\n",
-    "    label=\"La\",\n",
-    "    type_symbol=\"La\",\n",
+    "project_2.sample_models['lbco'].atom_sites.add(\n",
+    "    label='La',\n",
+    "    type_symbol='La',\n",
     "    fract_x=0,\n",
     "    fract_y=0,\n",
     "    fract_z=0,\n",
-    "    wyckoff_letter=\"a\",\n",
+    "    wyckoff_letter='a',\n",
     "    b_iso=0.95,\n",
     "    occupancy=0.5,\n",
     ")\n",
-    "project_2.sample_models[\"lbco\"].atom_sites.add(\n",
-    "    label=\"Ba\",\n",
-    "    type_symbol=\"Ba\",\n",
+    "project_2.sample_models['lbco'].atom_sites.add(\n",
+    "    label='Ba',\n",
+    "    type_symbol='Ba',\n",
     "    fract_x=0,\n",
     "    fract_y=0,\n",
     "    fract_z=0,\n",
-    "    wyckoff_letter=\"a\",\n",
+    "    wyckoff_letter='a',\n",
     "    b_iso=0.95,\n",
     "    occupancy=0.5,\n",
     ")\n",
-    "project_2.sample_models[\"lbco\"].atom_sites.add(\n",
-    "    label=\"Co\",\n",
-    "    type_symbol=\"Co\",\n",
+    "project_2.sample_models['lbco'].atom_sites.add(\n",
+    "    label='Co',\n",
+    "    type_symbol='Co',\n",
     "    fract_x=0.5,\n",
     "    fract_y=0.5,\n",
     "    fract_z=0.5,\n",
-    "    wyckoff_letter=\"b\",\n",
+    "    wyckoff_letter='b',\n",
     "    b_iso=0.80,\n",
     ")\n",
-    "project_2.sample_models[\"lbco\"].atom_sites.add(\n",
-    "    label=\"O\",\n",
-    "    type_symbol=\"O\",\n",
+    "project_2.sample_models['lbco'].atom_sites.add(\n",
+    "    label='O',\n",
+    "    type_symbol='O',\n",
     "    fract_x=0,\n",
     "    fract_y=0.5,\n",
     "    fract_z=0.5,\n",
-    "    wyckoff_letter=\"c\",\n",
+    "    wyckoff_letter='c',\n",
     "    b_iso=1.66,\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "3ef67cad",
+   "id": "81",
    "metadata": {},
    "source": [
     "### 🔗 Exercise 4: Assign Sample Model to Experiment\n",
@@ -1205,17 +1259,17 @@
   },
   {
    "cell_type": "code",
-   "id": "79a3d3f3",
+   "execution_count": null,
+   "id": "82",
    "metadata": {},
-   "source": [
-    "project_2.experiments[\"sim_lbco\"].linked_phases.add(id=\"lbco\", scale=1.0)"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.experiments['sim_lbco'].linked_phases.add(id='lbco', scale=1.0)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "60e8f0fc",
+   "id": "83",
    "metadata": {},
    "source": [
     "### 🚀 Exercise 5: Analyze and Fit the Data\n",
@@ -1234,20 +1288,20 @@
   },
   {
    "cell_type": "code",
-   "id": "72ba7c10",
+   "execution_count": null,
+   "id": "84",
    "metadata": {},
-   "source": [
-    "project_2.experiments[\"sim_lbco\"].linked_phases[\"lbco\"].scale.free = True\n",
-    "\n",
-    "for line_segment in project_2.experiments[\"sim_lbco\"].background:\n",
-    "    line_segment.y.free = True"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.experiments['sim_lbco'].linked_phases['lbco'].scale.free = True\n",
+    "\n",
+    "for line_segment in project_2.experiments['sim_lbco'].background:\n",
+    "    line_segment.y.free = True"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "76151a8e",
+   "id": "85",
    "metadata": {},
    "source": [
     "#### Exercise 5.2: Run Fitting\n",
@@ -1265,27 +1319,27 @@
   },
   {
    "cell_type": "code",
-   "id": "17d6fab3",
+   "execution_count": null,
+   "id": "86",
    "metadata": {},
-   "source": [
-    "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco')"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "cab87e11",
+   "execution_count": null,
+   "id": "87",
    "metadata": {},
+   "outputs": [],
    "source": [
     "project_2.analysis.fit()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "3e8311ca",
+   "id": "88",
    "metadata": {},
    "source": [
     "#### Exercise 5.3: Find the Misfit in the Fit\n",
@@ -1303,74 +1357,91 @@
     "4. The background points are not correct.\n",
     "\n",
     "**Solution**:\n",
-    "1. ❌ The conversion parameters from TOF to d-spacing were set based on the data reduction step. While they are\n",
-    "specific to each dataset and thus differ from those used for the Si data, the full reduction workflow has already been\n",
-    "validated with the Si fit. Therefore, they are not the cause of the misfit in this case.\n",
-    "2. ✅ The lattice parameters of the LBCO phase were set based on the CIF data, which is a good starting point, but they are not necessarily as accurate as needed for the fit. The lattice parameters may need to be refined.\n",
-    "3. ❌ The peak profile parameters do not change the position of the peaks, but rather their shape.\n",
-    "4. ❌ The background points affect the background level, but not the peak positions."
+    "1. ❌ The conversion parameters from TOF to d-spacing were set based on the\n",
+    "data reduction step. While they are specific to each dataset and thus differ\n",
+    "from those used for the Si data, the full reduction workflow has already been\n",
+    "validated with the Si fit. Therefore, they are not the cause of the misfit in\n",
+    "this case.\n",
+    "2. ✅ The lattice parameters of the LBCO phase were set based on the CIF data,\n",
+    "which is a good starting point, but they are not necessarily as accurate as\n",
+    "needed for the fit. The lattice parameters may need to be refined.\n",
+    "3. ❌ The peak profile parameters do not change the position of the peaks,\n",
+    "but rather their shape.\n",
+    "4. ❌ The background points affect the background level, but not the peak\n",
+    "positions."
    ]
   },
   {
    "cell_type": "code",
-   "id": "ee498b05",
+   "execution_count": null,
+   "id": "89",
    "metadata": {},
-   "source": [
-    "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco')"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "953a893f",
+   "id": "90",
    "metadata": {},
    "source": [
     "#### Exercise 5.4: Refine the LBCO Lattice Parameter\n",
     "\n",
     "To improve the fit, refine the lattice parameter of the LBCO phase.\n",
     "\n",
-    "**Hint**: To achieve this, we will set the `free` attribute of the `length_a` parameter\n",
-    "of the LBCO cell to `True`.\n",
+    "**Hint**: To achieve this, we will set the `free` attribute of the `length_a`\n",
+    "parameter of the LBCO cell to `True`.\n",
     "\n",
     "**Solution**:"
    ]
   },
   {
    "cell_type": "code",
-   "id": "ae225dae",
+   "execution_count": null,
+   "id": "91",
    "metadata": {},
-   "source": "project_2.sample_models[\"lbco\"].cell.length_a.free = True",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.sample_models['lbco'].cell.length_a.free = True"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "63f62a6a",
+   "execution_count": null,
+   "id": "92",
    "metadata": {},
+   "outputs": [],
    "source": [
     "project_2.analysis.fit()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\")",
-   "id": "3a68fe49"
+   "id": "93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco')"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "One of the main goals of this study was to refine the lattice parameter of the LBCO phase. As shown in the updated fit results, the overall fit has improved significantly, even though the change in cell length is less than 1% of the initial value. This demonstrates how even a small adjustment to the lattice parameter can have a substantial impact on the quality of the fit.",
-   "id": "8d9fd521e46b6f96"
+   "id": "94",
+   "metadata": {},
+   "source": [
+    "One of the main goals of this study was to refine the lattice parameter of\n",
+    "the LBCO phase. As shown in the updated fit results, the overall fit has\n",
+    "improved significantly, even though the change in cell length is less than\n",
+    "1% of the initial value. This demonstrates how even a small adjustment to the\n",
+    "lattice parameter can have a substantial impact on the quality of the fit."
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "95",
+   "metadata": {},
    "source": [
     "#### Exercise 5.5: Visualize the Fit Results in d-spacing\n",
     "\n",
@@ -1380,20 +1451,22 @@
     "`d_spacing` parameter to `True`.\n",
     "\n",
     "**Solution**:"
-   ],
-   "id": "29bbcdf6"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\", d_spacing=True)",
-   "id": "2cf8b9fa"
+   "id": "96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco', d_spacing=True)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "97",
+   "metadata": {},
    "source": [
     "#### Exercise 5.6: Refine the Peak Profile Parameters\n",
     "\n",
@@ -1406,20 +1479,22 @@
     "not necessarily optimal for the LBCO phase. This can be seen while inspecting\n",
     "the individual peaks in the diffraction pattern. For example, the calculated curve\n",
     "does not perfectly describe the peak at about 1.38 Å, as can be seen below:"
-   ],
-   "id": "3b43fc2dcc43818d"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\", d_spacing=True, x_min=1.35, x_max=1.40)",
-   "id": "83170be590740918"
+   "id": "98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco', d_spacing=True, x_min=1.35, x_max=1.40)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "99",
+   "metadata": {},
    "source": [
     "The peak profile parameters are determined based on both the instrument\n",
     "and the sample characteristics, so they can vary when analyzing different\n",
@@ -1433,44 +1508,47 @@
     "parameters of the LBCO phase.\n",
     "\n",
     "**Solution**:"
-   ],
-   "id": "c96f9e03c9cfe0c2"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "100",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "project_2.experiments[\"sim_lbco\"].peak.broad_gauss_sigma_0.free = True\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_gauss_sigma_1.free = True\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_gauss_sigma_2.free = True\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_mix_beta_0.free = True\n",
-    "project_2.experiments[\"sim_lbco\"].peak.broad_mix_beta_1.free = True\n",
-    "project_2.experiments[\"sim_lbco\"].peak.asym_alpha_0.free = True\n",
-    "project_2.experiments[\"sim_lbco\"].peak.asym_alpha_1.free = True"
-   ],
-   "id": "bf78c63d19ed7c98",
-   "execution_count": null
+    "project_2.experiments['sim_lbco'].peak.broad_gauss_sigma_0.free = True\n",
+    "project_2.experiments['sim_lbco'].peak.broad_gauss_sigma_1.free = True\n",
+    "project_2.experiments['sim_lbco'].peak.broad_gauss_sigma_2.free = True\n",
+    "project_2.experiments['sim_lbco'].peak.broad_mix_beta_0.free = True\n",
+    "project_2.experiments['sim_lbco'].peak.broad_mix_beta_1.free = True\n",
+    "project_2.experiments['sim_lbco'].peak.asym_alpha_0.free = True\n",
+    "project_2.experiments['sim_lbco'].peak.asym_alpha_1.free = True"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_2.analysis.fit()",
-   "id": "88b21bdfeac0a2ea"
+   "id": "101",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_2.analysis.fit()"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\", d_spacing=True, x_min=1.35, x_max=1.40)",
-   "id": "61c433e2478cd42a"
+   "id": "102",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco', d_spacing=True, x_min=1.35, x_max=1.40)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "9947fdf6",
+   "id": "103",
    "metadata": {},
    "source": [
     "#### Exercise 5.7: Find Undefined Features\n",
@@ -1479,27 +1557,28 @@
     "significantly improved, but inspect the diffraction pattern again. Are you noticing\n",
     "anything undefined?\n",
     "\n",
-    "**Hint**: While the fit is now significantly better, there are still some unexplained peaks\n",
-    "in the diffraction pattern. These peaks are not accounted for by the LBCO phase.\n",
-    "For example, if you zoom in on the region around 1.6 Å (or 95,000 μs), you will\n",
-    "notice that the rightmost peak is not explained by the LBCO phase at all.\n",
+    "**Hint**: While the fit is now significantly better, there are still some\n",
+    "unexplained peaks in the diffraction pattern. These peaks are not accounted\n",
+    "for by the LBCO phase. For example, if you zoom in on the region around\n",
+    "1.6 Å (or 95,000 μs), you will notice that the rightmost peak is not\n",
+    "explained by the LBCO phase at all.\n",
     "\n",
     "**Solution**:"
    ]
   },
   {
    "cell_type": "code",
-   "id": "d52d3593",
+   "execution_count": null,
+   "id": "104",
    "metadata": {},
-   "source": [
-    "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\", x_min=1.53, x_max=1.7, d_spacing=True)"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco', x_min=1.53, x_max=1.7, d_spacing=True)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "1a6bd5ab",
+   "id": "105",
    "metadata": {},
    "source": [
     "#### Exercise 5.8: Identify the Cause of the Unexplained Peaks\n",
@@ -1512,7 +1591,7 @@
     "\n",
     "**Solution**:\n",
     "1. ❌ In principle, this could be the case, as sometimes the presence of\n",
-    "extra peaks in the diffraction pattern can indicate a lower symmetry\n",
+    "extra peaks in the diffraction pattern can indicate lower symmetry\n",
     "than the one used in the model, or that the model is not complete. However,\n",
     "in this case, the LBCO phase is correctly modeled based on the CIF data.\n",
     "2. ✅ The unexplained peaks are due to the presence of an impurity phase\n",
@@ -1525,7 +1604,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46addc5f",
+   "id": "106",
    "metadata": {},
    "source": [
     "#### Exercise 5.9: Identify the impurity phase\n",
@@ -1546,18 +1625,18 @@
   },
   {
    "cell_type": "code",
-   "id": "e9639a9b",
+   "execution_count": null,
+   "id": "107",
    "metadata": {},
-   "source": [
-    "project_1.plot_meas_vs_calc(expt_name=\"sim_si\", x_min=1, x_max=1.7, d_spacing=True)\n",
-    "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\", x_min=1, x_max=1.7, d_spacing=True)"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_1.plot_meas_vs_calc(expt_name='sim_si', x_min=1, x_max=1.7, d_spacing=True)\n",
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco', x_min=1, x_max=1.7, d_spacing=True)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "9729a3e3",
+   "id": "108",
    "metadata": {},
    "source": [
     "#### Exercise 5.10: Create a Second Sample Model – Si as Impurity\n",
@@ -1575,7 +1654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32078229",
+   "id": "109",
    "metadata": {},
    "source": [
     "**Set Space Group**"
@@ -1583,28 +1662,28 @@
   },
   {
    "cell_type": "code",
-   "id": "12e2f067",
+   "execution_count": null,
+   "id": "110",
    "metadata": {},
-   "source": [
-    "project_2.sample_models.add(name=\"si\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.sample_models.add(name='si')"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "9d5dfa50",
+   "execution_count": null,
+   "id": "111",
    "metadata": {},
-   "source": [
-    "project_2.sample_models[\"si\"].space_group.name_h_m = \"F d -3 m\"\n",
-    "project_2.sample_models[\"si\"].space_group.it_coordinate_system_code = \"2\""
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.sample_models['si'].space_group.name_h_m = 'F d -3 m'\n",
+    "project_2.sample_models['si'].space_group.it_coordinate_system_code = '2'"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "64e97830",
+   "id": "112",
    "metadata": {},
    "source": [
     "**Set Lattice Parameters**"
@@ -1612,17 +1691,17 @@
   },
   {
    "cell_type": "code",
-   "id": "2e147ff4",
+   "execution_count": null,
+   "id": "113",
    "metadata": {},
-   "source": [
-    "project_2.sample_models[\"si\"].cell.length_a = 5.43"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.sample_models['si'].cell.length_a = 5.43"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "4054a7d1",
+   "id": "114",
    "metadata": {},
    "source": [
     "**Set Atom Sites**"
@@ -1630,25 +1709,25 @@
   },
   {
    "cell_type": "code",
-   "id": "e6654513",
+   "execution_count": null,
+   "id": "115",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "project_2.sample_models[\"si\"].atom_sites.add(\n",
-    "    label=\"Si\",\n",
-    "    type_symbol=\"Si\",\n",
+    "project_2.sample_models['si'].atom_sites.add(\n",
+    "    label='Si',\n",
+    "    type_symbol='Si',\n",
     "    fract_x=0,\n",
     "    fract_y=0,\n",
     "    fract_z=0,\n",
-    "    wyckoff_letter=\"a\",\n",
+    "    wyckoff_letter='a',\n",
     "    b_iso=0.89,\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "1bab0afa",
+   "id": "116",
    "metadata": {},
    "source": [
     "**🔗 Assign Sample Model to Experiment**"
@@ -1656,17 +1735,17 @@
   },
   {
    "cell_type": "code",
-   "id": "96d4c73f",
+   "execution_count": null,
+   "id": "117",
    "metadata": {},
-   "source": [
-    "project_2.experiments[\"sim_lbco\"].linked_phases.add(id=\"si\", scale=1.0)"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.experiments['sim_lbco'].linked_phases.add(id='si', scale=1.0)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "4aa8f8f7",
+   "id": "118",
    "metadata": {},
    "source": [
     "#### Exercise 5.11: Refine the Scale of the Si Phase\n",
@@ -1691,17 +1770,17 @@
   },
   {
    "cell_type": "code",
-   "id": "8e6bc18e",
+   "execution_count": null,
+   "id": "119",
    "metadata": {},
-   "source": [
-    "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco')"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "2a01d9fd",
+   "id": "120",
    "metadata": {},
    "source": [
     "As you can see, the calculated pattern is now the sum of both phases,\n",
@@ -1713,17 +1792,17 @@
   },
   {
    "cell_type": "code",
-   "id": "0a683b74",
+   "execution_count": null,
+   "id": "121",
    "metadata": {},
-   "source": [
-    "project_2.experiments[\"sim_lbco\"].linked_phases[\"si\"].scale.free = True"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.experiments['sim_lbco'].linked_phases['si'].scale.free = True"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "c7596964",
+   "id": "122",
    "metadata": {},
    "source": [
     "**Run Fitting**\n",
@@ -1733,68 +1812,71 @@
   },
   {
    "cell_type": "code",
-   "id": "a7216729",
+   "execution_count": null,
+   "id": "123",
    "metadata": {},
+   "outputs": [],
    "source": [
     "project_2.analysis.fit()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "b62290c6",
+   "id": "124",
    "metadata": {},
    "source": [
     "**Visualize Fit Results**\n",
     "\n",
     "Let's plot the measured diffraction pattern and the calculated diffraction\n",
-    "pattern both for the full range and for a zoomed-in region around the previously unexplained\n",
-    "peak near 95,000 μs. The calculated pattern will be the sum of the two phases."
+    "pattern both for the full range and for a zoomed-in region around the previously\n",
+    "unexplained peak near 95,000 μs. The calculated pattern will be the sum of\n",
+    "the two phases."
    ]
   },
   {
    "cell_type": "code",
-   "id": "38004527",
+   "execution_count": null,
+   "id": "125",
    "metadata": {},
-   "source": [
-    "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\")"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco')"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "6fc93114",
+   "execution_count": null,
+   "id": "126",
    "metadata": {},
-   "source": [
-    "project_2.plot_meas_vs_calc(expt_name=\"sim_lbco\", x_min=88000, x_max=101000)"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "project_2.plot_meas_vs_calc(expt_name='sim_lbco', x_min=88000, x_max=101000)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "d9315e63",
+   "id": "127",
    "metadata": {},
    "source": [
-    "All previously unexplained peaks are now accounted for in the pattern, and the fit is improved.\n",
-    "Some discrepancies in the peak intensities remain, but\n",
+    "All previously unexplained peaks are now accounted for in the pattern, and the\n",
+    "fit is improved. Some discrepancies in the peak intensities remain, but\n",
     "further improvements would require more advanced data reduction and analysis,\n",
     "which are beyond the scope of this tutorial.\n",
     "\n",
     "#### Final Remarks\n",
     "\n",
     "In this part of the tutorial, we have demonstrated how to use EasyDiffraction\n",
-    "to refine lattice parameters for a more complex crystal structure, La₀.₅Ba₀.₅CoO₃ (LBCO).\n",
-    "In real experiments, additional parameters, such as atomic positions, occupancies, and atomic displacement factors, can also be refined to further improve the fit.\n",
-    "However, we will stop here, as the purpose of this part of the tutorial is to demonstrate the practical use of\n",
+    "to refine lattice parameters for a more complex crystal structure,\n",
+    "La₀.₅Ba₀.₅CoO₃ (LBCO). In real experiments, additional parameters, such as\n",
+    "atomic positions, occupancies, and atomic displacement factors, can also be\n",
+    "refined to further improve the fit. However, we will stop here, as the purpose\n",
+    "of this part of the tutorial is to demonstrate the practical use of\n",
     "EasyDiffraction for fitting powder diffraction data."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "51f12db7",
+   "id": "128",
    "metadata": {},
    "source": [
     "## 🎁 Bonus\n",
@@ -1806,7 +1888,7 @@
     "To continue learning and exploring more features of\n",
     "the EasyDiffraction library, you can visit the official tutorial page\n",
     "and select one of the many available tutorials:\n",
-    "https://easyscience.github.io/diffraction-lib/tutorials/"
+    "https://docs.easydiffraction.org/lib/tutorials/"
    ]
   }
  ],

--- a/requirements.in
+++ b/requirements.in
@@ -27,4 +27,4 @@ scippnexus
 scipy
 sphinxcontrib-mermaid
 scitacean[sftp]
-git+https://github.com/easyscience/diffraction-lib@d-spacing#egg=easydiffraction
+easydiffraction

--- a/requirements.in
+++ b/requirements.in
@@ -27,4 +27,4 @@ scippnexus
 scipy
 sphinxcontrib-mermaid
 scitacean[sftp]
-easydiffraction
+easydiffraction[visualization]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,19 +30,12 @@ attrs==25.3.0
     #   referencing
 babel==2.17.0
     # via
-    #   mkdocs-material
     #   pydata-sphinx-theme
     #   sphinx
-backrefs==5.9
-    # via mkdocs-material
 bcrypt==4.3.0
     # via paramiko
 beautifulsoup4==4.13.3
-    # via
-    #   nbconvert
-    #   pydata-sphinx-theme
-bleach[css]==6.2.0
-    # via nbconvert
+    # via pydata-sphinx-theme
 build==1.2.2.post1
     # via pip-tools
 bumps==0.9.3
@@ -64,15 +57,10 @@ click==8.1.8
     # via
     #   jupyter-book
     #   jupyter-cache
-    #   mkdocs
-    #   mkdocstrings
     #   pip-tools
     #   sphinx-external-toc
 colorama==0.4.6
-    # via
-    #   easydiffraction
-    #   griffe
-    #   mkdocs-material
+    # via easydiffraction
 comm==0.2.2
     # via
     #   ipykernel
@@ -87,14 +75,10 @@ cryspy==0.7.8
     # via easydiffraction
 cycler==0.12.1
     # via matplotlib
-darkdetect==0.8.0
-    # via easydiffraction
 debugpy==1.8.13
     # via ipykernel
 decorator==5.2.1
     # via ipython
-defusedxml==0.7.1
-    # via nbconvert
 dfo-ls==1.5.4
     # via
     #   easydiffraction
@@ -121,7 +105,7 @@ docutils==0.21.2
     #   sphinxcontrib-bibtex
 dynesty==2.1.5
     # via -r requirements.in
-easydiffraction @ git+https://github.com/easyscience/diffraction-lib@d-spacing
+easydiffraction==0.5.2
     # via -r requirements.in
 easyscience==1.3.0
     # via -r requirements.in
@@ -131,8 +115,6 @@ email-validator==2.2.0
     #   scitacean
 emcee==3.1.6
     # via -r requirements.in
-execnet==2.1.1
-    # via pytest-xdist
 executing==2.2.0
     # via
     #   stack-data
@@ -147,12 +129,8 @@ fonttools==4.57.0
     # via matplotlib
 gemmi==0.7.3
     # via easydiffraction
-ghp-import==2.1.0
-    # via mkdocs
 graphviz==0.20.3
     # via -r requirements.in
-griffe==1.7.3
-    # via mkdocstrings-python
 h11==0.14.0
     # via httpcore
 h5py==3.13.0
@@ -183,10 +161,7 @@ iniconfig==2.1.0
 ipydatawidgets==4.3.5
     # via pythreejs
 ipykernel==6.29.5
-    # via
-    #   mkdocs-jupyter
-    #   myst-nb
-    #   nbmake
+    # via myst-nb
 ipympl==0.9.7
     # via -r requirements.in
 ipython==8.35.0
@@ -208,11 +183,7 @@ jedi==0.19.2
 jinja2==3.1.6
     # via
     #   jupyter-book
-    #   mkdocs
-    #   mkdocs-material
-    #   mkdocstrings
     #   myst-parser
-    #   nbconvert
     #   sphinx
 json-tricks==3.17.3
     # via libpyvinyl
@@ -237,16 +208,11 @@ jupyter-core==5.7.2
     #   ipykernel
     #   jupyter-client
     #   nbclient
-    #   nbconvert
     #   nbformat
-jupyterlab-pygments==0.3.0
-    # via nbconvert
 jupyterlab-widgets==3.0.13
     # via ipywidgets
 jupyterquiz==2.8.1
     # via -r requirements.in
-jupytext==1.17.2
-    # via mkdocs-jupyter
 kiwisolver==1.4.8
     # via matplotlib
 latexcodec==3.0.0
@@ -263,25 +229,12 @@ lmfit==1.3.3
     # via
     #   easydiffraction
     #   easyscience
-markdown==3.8.2
-    # via
-    #   mkdocs
-    #   mkdocs-autorefs
-    #   mkdocs-material
-    #   mkdocstrings
-    #   pymdown-extensions
 markdown-it-py==3.0.0
     # via
-    #   jupytext
     #   mdit-py-plugins
     #   myst-parser
 markupsafe==3.0.2
-    # via
-    #   jinja2
-    #   mkdocs
-    #   mkdocs-autorefs
-    #   mkdocstrings
-    #   nbconvert
+    # via jinja2
 matplotlib==3.10.1
     # via
     #   -r requirements.in
@@ -300,49 +253,9 @@ mcstasscript==0.0.74
 mcstastox==0.0.11
     # via -r requirements.in
 mdit-py-plugins==0.4.2
-    # via
-    #   jupytext
-    #   myst-parser
+    # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-mergedeep==1.3.4
-    # via
-    #   mkdocs
-    #   mkdocs-get-deps
-mistune==3.1.3
-    # via nbconvert
-mkdocs==1.6.1
-    # via
-    #   easydiffraction
-    #   mkdocs-autorefs
-    #   mkdocs-jupyter
-    #   mkdocs-markdownextradata-plugin
-    #   mkdocs-material
-    #   mkdocs-plugin-inline-svg
-    #   mkdocstrings
-mkdocs-autorefs==1.2.0
-    # via
-    #   easydiffraction
-    #   mkdocstrings
-    #   mkdocstrings-python
-mkdocs-get-deps==0.2.0
-    # via mkdocs
-mkdocs-jupyter==0.25.1
-    # via easydiffraction
-mkdocs-markdownextradata-plugin==0.2.6
-    # via easydiffraction
-mkdocs-material==9.6.15
-    # via
-    #   easydiffraction
-    #   mkdocs-jupyter
-mkdocs-material-extensions==1.3.1
-    # via mkdocs-material
-mkdocs-plugin-inline-svg==0.1.0
-    # via easydiffraction
-mkdocstrings==0.27.0
-    # via mkdocstrings-python
-mkdocstrings-python==1.13.0
-    # via easydiffraction
 mpltoolbox==24.5.1
     # via
     #   -r requirements.in
@@ -355,26 +268,15 @@ myst-parser==3.0.1
     # via
     #   jupyter-book
     #   myst-nb
-narwhals==1.47.0
-    # via plotly
 nbclient==0.10.2
     # via
     #   jupyter-cache
     #   myst-nb
-    #   nbconvert
-    #   nbmake
-nbconvert==7.16.6
-    # via mkdocs-jupyter
 nbformat==5.10.4
     # via
     #   jupyter-cache
-    #   jupytext
     #   myst-nb
     #   nbclient
-    #   nbconvert
-    #   nbmake
-nbmake==1.5.5
-    # via easydiffraction
 nest-asyncio==1.6.0
     # via ipykernel
 numpy==2.2.4
@@ -408,34 +310,23 @@ packaging==24.2
     # via
     #   build
     #   ipykernel
-    #   jupytext
     #   lazy-loader
     #   matplotlib
-    #   mkdocs
-    #   nbconvert
-    #   plotly
     #   pooch
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   sphinx-jupyterbook-latex
     #   xarray
-paginate==0.5.7
-    # via mkdocs-material
 pandas==2.2.3
     # via
     #   -r requirements.in
     #   dfo-ls
-    #   easydiffraction
     #   xarray
-pandocfilters==1.5.1
-    # via nbconvert
 paramiko==3.5.1
     # via scitacean
 parso==0.8.4
     # via jedi
-pathspec==0.12.1
-    # via mkdocs
 pexpect==4.9.0
     # via ipython
 pillow==11.1.0
@@ -451,8 +342,6 @@ pip-tools==7.4.1
 platformdirs==4.3.7
     # via
     #   jupyter-core
-    #   mkdocs-get-deps
-    #   mkdocstrings
     #   pint
     #   pooch
     #   xraydb
@@ -460,8 +349,6 @@ plopp==25.3.0
     # via
     #   -r requirements.in
     #   scippneutron
-plotly==6.0.1
-    # via easydiffraction
 pluggy==1.5.0
     # via pytest
 ply==3.11
@@ -506,16 +393,8 @@ pygments==2.19.1
     # via
     #   accessible-pygments
     #   ipython
-    #   mkdocs-jupyter
-    #   mkdocs-material
-    #   nbconvert
-    #   nbmake
     #   pydata-sphinx-theme
     #   sphinx
-pymdown-extensions==10.16
-    # via
-    #   mkdocs-material
-    #   mkdocstrings
 pynacl==1.5.0
     # via paramiko
 pyparsing==3.2.3
@@ -525,16 +404,9 @@ pyproject-hooks==1.2.0
     #   build
     #   pip-tools
 pytest==8.3.5
-    # via
-    #   -r requirements.in
-    #   easydiffraction
-    #   nbmake
-    #   pytest-xdist
-pytest-xdist==3.8.0
-    # via easydiffraction
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
-    #   ghp-import
     #   jupyter-client
     #   matplotlib
     #   pandas
@@ -547,23 +419,14 @@ pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via
-    #   easydiffraction
     #   jupyter-book
     #   jupyter-cache
-    #   jupytext
     #   mcstasscript
-    #   mkdocs
-    #   mkdocs-get-deps
-    #   mkdocs-markdownextradata-plugin
     #   myst-nb
     #   myst-parser
     #   pybtex
-    #   pymdown-extensions
-    #   pyyaml-env-tag
     #   sphinx-external-toc
     #   sphinxcontrib-mermaid
-pyyaml-env-tag==1.1
-    # via mkdocs
 pyzmq==26.4.0
     # via
     #   ipykernel
@@ -574,7 +437,6 @@ referencing==0.36.2
     #   jsonschema-specifications
 requests==2.32.3
     # via
-    #   mkdocs-material
     #   pooch
     #   sphinx
 rpds-py==0.24.0
@@ -680,8 +542,6 @@ tabulate==0.9.0
     # via
     #   easydiffraction
     #   jupyter-cache
-tinycss2==1.4.0
-    # via bleach
 tomli==2.2.1
     # via scitacean
 tornado==6.4.2
@@ -699,7 +559,6 @@ traitlets==5.14.3
     #   jupyter-core
     #   matplotlib-inline
     #   nbclient
-    #   nbconvert
     #   nbformat
     #   pythreejs
     #   traittypes
@@ -736,16 +595,10 @@ urllib3==2.3.0
     # via requests
 varname==0.15.0
     # via easydiffraction
-watchdog==6.0.0
-    # via mkdocs
 wcwidth==0.2.13
     # via
     #   prettytable
     #   prompt-toolkit
-webencodings==0.5.1
-    # via
-    #   bleach
-    #   tinycss2
 wheel==0.45.1
     # via
     #   pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,6 +86,8 @@ cryspy==0.7.8
     # via easydiffraction
 cycler==0.12.1
     # via matplotlib
+darkdetect==0.8.0
+    # via easydiffraction
 debugpy==1.8.16
     # via ipykernel
 decorator==5.2.1
@@ -117,7 +119,7 @@ docutils==0.21.2
     #   sphinxcontrib-bibtex
 dynesty==2.1.5
     # via -r requirements.in
-easydiffraction==0.5.3
+easydiffraction[visualization]==0.5.3
     # via -r requirements.in
 easyscience==1.3.0
     # via -r requirements.in
@@ -356,6 +358,7 @@ pandas==2.3.1
     # via
     #   -r requirements.in
     #   dfo-ls
+    #   easydiffraction
     #   xarray
 paramiko==4.0.0
     # via scitacean
@@ -383,8 +386,10 @@ plopp==25.7.1
     # via
     #   -r requirements.in
     #   scippneutron
-plotly==6.2.0
-    # via bumps
+plotly==6.0.1
+    # via
+    #   bumps
+    #   easydiffraction
 pluggy==1.6.0
     # via pytest
 ply==3.11
@@ -409,6 +414,8 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
+py3dmol==2.5.2
+    # via easydiffraction
 pybtex==0.25.1
     # via
     #   pybtex-docutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,17 @@
 #
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.12.15
+    # via bumps
+aiosignal==1.4.0
+    # via aiohttp
 alabaster==0.7.16
     # via sphinx
 annotated-types==0.7.0
     # via pydantic
-anyio==4.9.0
+anyio==4.10.0
     # via httpx
 appnope==0.1.4
     # via ipykernel
@@ -25,6 +31,7 @@ asttokens==3.0.0
     # via stack-data
 attrs==25.3.0
     # via
+    #   aiohttp
     #   jsonschema
     #   jupyter-cache
     #   referencing
@@ -34,15 +41,19 @@ babel==2.17.0
     #   sphinx
 bcrypt==4.3.0
     # via paramiko
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via pydata-sphinx-theme
-build==1.2.2.post1
+bidict==0.23.1
+    # via python-socketio
+blinker==1.9.0
+    # via bumps
+build==1.3.0
     # via pip-tools
-bumps==0.9.3
+bumps==1.0.2
     # via
     #   easydiffraction
     #   easyscience
-certifi==2025.1.31
+certifi==2025.8.3
     # via
     #   httpcore
     #   httpx
@@ -51,9 +62,9 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.3
     # via requests
-click==8.1.8
+click==8.2.1
     # via
     #   jupyter-book
     #   jupyter-cache
@@ -61,21 +72,21 @@ click==8.1.8
     #   sphinx-external-toc
 colorama==0.4.6
     # via easydiffraction
-comm==0.2.2
+comm==0.2.3
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.3
     # via matplotlib
 corner==2.2.3
     # via -r requirements.in
-cryptography==44.0.2
+cryptography==45.0.6
     # via paramiko
 cryspy==0.7.8
     # via easydiffraction
 cycler==0.12.1
     # via matplotlib
-debugpy==1.8.13
+debugpy==1.8.16
     # via ipykernel
 decorator==5.2.1
     # via ipython
@@ -85,12 +96,13 @@ dfo-ls==1.5.4
     #   easyscience
 diffpy-pdffit2==1.5.1
     # via easydiffraction
-diffpy-structure==3.3.0
+diffpy-structure==3.3.1
     # via diffpy-pdffit2
-diffpy-utils==3.6.0
+diffpy-utils==3.6.1
     # via easydiffraction
 dill==0.3.5.1
     # via
+    #   bumps
     #   libpyvinyl
     #   lmfit
 dnspython==2.7.0
@@ -105,7 +117,7 @@ docutils==0.21.2
     #   sphinxcontrib-bibtex
 dynesty==2.1.5
     # via -r requirements.in
-easydiffraction==0.5.2
+easydiffraction==0.5.3
     # via -r requirements.in
 easyscience==1.3.0
     # via -r requirements.in
@@ -125,22 +137,29 @@ flexcache==0.3
     # via pint
 flexparser==0.4
     # via pint
-fonttools==4.57.0
+fonttools==4.59.0
     # via matplotlib
+frozenlist==1.7.0
+    # via
+    #   aiohttp
+    #   aiosignal
 gemmi==0.7.3
     # via easydiffraction
-graphviz==0.20.3
+graphviz==0.21
     # via -r requirements.in
-h11==0.14.0
-    # via httpcore
-h5py==3.13.0
+h11==0.16.0
+    # via
+    #   httpcore
+    #   wsproto
+h5py==3.14.0
     # via
     #   -r requirements.in
+    #   bumps
     #   libpyvinyl
     #   mcstastox
     #   scippneutron
     #   scippnexus
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via scitacean
@@ -150,28 +169,31 @@ idna==3.10
     #   email-validator
     #   httpx
     #   requests
+    #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via
     #   jupyter-cache
     #   myst-nb
 iniconfig==2.1.0
     # via pytest
+invoke==2.2.0
+    # via paramiko
 ipydatawidgets==4.3.5
     # via pythreejs
-ipykernel==6.29.5
+ipykernel==6.30.1
     # via myst-nb
 ipympl==0.9.7
     # via -r requirements.in
-ipython==8.35.0
+ipython==8.37.0
     # via
     #   -r requirements.in
     #   ipykernel
     #   ipympl
     #   ipywidgets
     #   myst-nb
-ipywidgets==8.1.5
+ipywidgets==8.1.7
     # via
     #   -r requirements.in
     #   ipydatawidgets
@@ -183,17 +205,18 @@ jedi==0.19.2
 jinja2==3.1.6
     # via
     #   jupyter-book
+    #   mpld3
     #   myst-parser
     #   sphinx
 json-tricks==3.17.3
     # via libpyvinyl
 jsons==1.6.3
     # via libpyvinyl
-jsonschema==4.23.0
+jsonschema==4.25.0
     # via
     #   jupyter-book
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
 jupyter-book==1.0.4.post1
     # via -r requirements.in
@@ -203,19 +226,19 @@ jupyter-client==8.6.3
     # via
     #   ipykernel
     #   nbclient
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via
     #   ipykernel
     #   jupyter-client
     #   nbclient
     #   nbformat
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.15
     # via ipywidgets
-jupyterquiz==2.8.1
+jupyterquiz==2.9.6.2
     # via -r requirements.in
-kiwisolver==1.4.8
+kiwisolver==1.4.9
     # via matplotlib
-latexcodec==3.0.0
+latexcodec==3.0.1
     # via pybtex
 lazy-loader==0.4
     # via
@@ -225,7 +248,7 @@ libpyvinyl==1.3.0
     # via mcstasscript
 linkify-it-py==2.0.3
     # via jupyter-book
-lmfit==1.3.3
+lmfit==1.3.4
     # via
     #   easydiffraction
     #   easyscience
@@ -235,13 +258,15 @@ markdown-it-py==3.0.0
     #   myst-parser
 markupsafe==3.0.2
     # via jinja2
-matplotlib==3.10.1
+matplotlib==3.10.5
     # via
     #   -r requirements.in
+    #   bumps
     #   corner
     #   cryspy
     #   ipympl
     #   mcstasscript
+    #   mpld3
     #   mpltoolbox
     #   plopp
 matplotlib-inline==0.1.7
@@ -252,22 +277,30 @@ mcstasscript==0.0.74
     # via -r requirements.in
 mcstastox==0.0.11
     # via -r requirements.in
-mdit-py-plugins==0.4.2
+mdit-py-plugins==0.5.0
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-mpltoolbox==24.5.1
+mpld3==0.5.11
+    # via bumps
+mpltoolbox==25.5.0
     # via
     #   -r requirements.in
     #   scippneutron
 mpmath==1.3.0
     # via sympy
-myst-nb==1.2.0
+multidict==6.6.4
+    # via
+    #   aiohttp
+    #   yarl
+myst-nb==1.3.0
     # via jupyter-book
 myst-parser==3.0.1
     # via
     #   jupyter-book
     #   myst-nb
+narwhals==2.1.0
+    # via plotly
 nbclient==0.10.2
     # via
     #   jupyter-cache
@@ -279,9 +312,10 @@ nbformat==5.10.4
     #   nbclient
 nest-asyncio==1.6.0
     # via ipykernel
-numpy==2.2.4
+numpy==2.3.2
     # via
     #   -r requirements.in
+    #   bumps
     #   contourpy
     #   cryspy
     #   dfo-ls
@@ -297,7 +331,6 @@ numpy==2.2.4
     #   matplotlib
     #   mcstasscript
     #   mcstastox
-    #   mpltoolbox
     #   pandas
     #   pycifrw
     #   pythreejs
@@ -306,30 +339,31 @@ numpy==2.2.4
     #   scipy
     #   xarray
     #   xraydb
-packaging==24.2
+packaging==25.0
     # via
     #   build
     #   ipykernel
     #   lazy-loader
     #   matplotlib
+    #   plotly
     #   pooch
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   sphinx-jupyterbook-latex
     #   xarray
-pandas==2.2.3
+pandas==2.3.1
     # via
     #   -r requirements.in
     #   dfo-ls
     #   xarray
-paramiko==3.5.1
+paramiko==4.0.0
     # via scitacean
 parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==11.1.0
+pillow==11.3.0
     # via
     #   ipympl
     #   matplotlib
@@ -337,19 +371,21 @@ pint==0.24.4
     # via
     #   easyscience
     #   libpyvinyl
-pip-tools==7.4.1
+pip-tools==7.5.0
     # via -r requirements.in
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via
     #   jupyter-core
     #   pint
     #   pooch
     #   xraydb
-plopp==25.3.0
+plopp==25.7.1
     # via
     #   -r requirements.in
     #   scippneutron
-pluggy==1.5.0
+plotly==6.2.0
+    # via bumps
+pluggy==1.6.0
     # via pytest
 ply==3.11
     # via
@@ -361,15 +397,19 @@ pooch==1.8.2
     #   easydiffraction
 prettytable==3.16.0
     # via pycifrw
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via ipython
+propcache==0.3.2
+    # via
+    #   aiohttp
+    #   yarl
 psutil==7.0.0
     # via ipykernel
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pybtex==0.24.0
+pybtex==0.25.1
     # via
     #   pybtex-docutils
     #   sphinxcontrib-bibtex
@@ -381,19 +421,20 @@ pycifstar==0.3.0
     # via cryspy
 pycparser==2.22
     # via cffi
-pydantic==2.11.2
+pydantic==2.11.7
     # via
     #   scippneutron
     #   scitacean
-pydantic-core==2.33.1
+pydantic-core==2.33.2
     # via pydantic
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   accessible-pygments
     #   ipython
     #   pydata-sphinx-theme
+    #   pytest
     #   sphinx
 pynacl==1.5.0
     # via paramiko
@@ -403,7 +444,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.3.5
+pytest==8.4.1
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -413,6 +454,10 @@ python-dateutil==2.9.0.post0
     #   scippneutron
     #   scippnexus
     #   scitacean
+python-engineio==4.12.2
+    # via python-socketio
+python-socketio==5.13.0
+    # via bumps
 pythreejs==2.4.2
     # via -r requirements.in
 pytz==2025.2
@@ -427,7 +472,7 @@ pyyaml==6.0.2
     #   pybtex
     #   sphinx-external-toc
     #   sphinxcontrib-mermaid
-pyzmq==26.4.0
+pyzmq==27.0.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -435,29 +480,30 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.3
+requests==2.32.4
     # via
     #   pooch
     #   sphinx
-rpds-py==0.24.0
+rpds-py==0.27.0
     # via
     #   jsonschema
     #   referencing
-scipp==25.4.0
+scipp==25.5.1
     # via
     #   -r requirements.in
     #   easyscience
     #   scippneutron
     #   scippnexus
-scippneutron==25.2.1
+scippneutron==25.7.0
     # via -r requirements.in
-scippnexus==25.4.0
+scippnexus==25.6.0
     # via
     #   -r requirements.in
     #   scippneutron
-scipy==1.15.2
+scipy==1.16.1
     # via
     #   -r requirements.in
+    #   bumps
     #   cryspy
     #   dfo-ls
     #   diffpy-utils
@@ -467,17 +513,17 @@ scipy==1.15.2
     #   scippneutron
     #   scippnexus
     #   xraydb
-scitacean[sftp]==25.3.2
+scitacean[sftp]==25.8.0
     # via -r requirements.in
+simple-websocket==1.1.0
+    # via python-engineio
 six==1.17.0
-    # via
-    #   pybtex
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.3.1
     # via anyio
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 sphinx==7.4.7
     # via
@@ -516,7 +562,7 @@ sphinx-togglebutton==0.3.2
     # via jupyter-book
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-bibtex==2.6.3
+sphinxcontrib-bibtex==2.6.5
     # via jupyter-book
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
@@ -530,7 +576,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.40
+sqlalchemy==2.0.43
     # via
     #   jupyter-cache
     #   xraydb
@@ -544,13 +590,12 @@ tabulate==0.9.0
     #   jupyter-cache
 tomli==2.2.1
     # via scitacean
-tornado==6.4.2
+tornado==6.5.2
     # via
     #   ipykernel
     #   jupyter-client
 traitlets==5.14.3
     # via
-    #   comm
     #   ipykernel
     #   ipympl
     #   ipython
@@ -564,8 +609,9 @@ traitlets==5.14.3
     #   traittypes
 traittypes==0.2.1
     # via ipydatawidgets
-typing-extensions==4.13.1
+typing-extensions==4.14.1
     # via
+    #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   flexcache
@@ -579,7 +625,7 @@ typing-extensions==4.13.1
     #   referencing
     #   sqlalchemy
     #   typing-inspection
-typing-inspection==0.4.0
+typing-inspection==0.4.1
     # via pydantic
 typish==1.9.3
     # via jsons
@@ -587,11 +633,11 @@ tzdata==2025.2
     # via pandas
 uc-micro-py==1.0.3
     # via linkify-it-py
-uncertainties==3.2.2
+uncertainties==3.2.3
     # via
     #   easyscience
     #   lmfit
-urllib3==2.3.0
+urllib3==2.5.0
     # via requests
 varname==0.15.0
     # via easydiffraction
@@ -603,13 +649,17 @@ wheel==0.45.1
     # via
     #   pip-tools
     #   sphinx-togglebutton
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via ipywidgets
-xarray==2025.3.1
+wsproto==1.2.0
+    # via simple-websocket
+xarray==2025.7.1
     # via easyscience
-xraydb==4.5.6
+xraydb==4.5.8
     # via diffpy-utils
-zipp==3.21.0
+yarl==1.20.1
+    # via aiohttp
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This PR switches the EasyDiffraction dependency from the GitHub repository to the official PyPI release.
It also updates the related diffraction data analysis Jupyter notebook to reflect this change and includes minor adjustments.