### PR TITLE
Make unused hint tag collapse cell content in student notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ There are a few tags that are often used. See [this page](https://jupyterbook.or
 - `remove-cell`:
     Not included in the workbooks. Also used by `jupyter-book`.
 - `dmsc-school-hint`:
-    Editable cell with hints for students.
-    The tagged cell in the workbook will not be read-only,
-    unless it is already read-only in the textbook.
+    Collapse the content of the cell in the workbooks. The content can be expanded by clicking on the cell.
 - `dmsc-school-keep`:
     Will not be edited or removed. It overwrites all other tags.
 

--- a/strip_solutions.py
+++ b/strip_solutions.py
@@ -35,17 +35,23 @@ def clean(filepath, destination, add_mpl_widget_cell=False):
         out.append(WIDGET_CELL)
     for cell in obj["cells"]:
         if "tags" in cell["metadata"]:
+            to_be_appended = None
             if ("solution" in cell["metadata"]["tags"]) and (
                 "dmsc-school-keep" not in cell["metadata"]["tags"]
             ):
-                out.append(EMPTY_CELL)
+                to_be_appended = EMPTY_CELL
             elif (
                 ("remove-cell" in cell["metadata"]["tags"])
                 and ("dmsc-school-keep" not in cell["metadata"]["tags"])
             ) or ("dmsc-school-remove" in cell["metadata"]["tags"]):
                 pass
             else:
-                out.append(cell)
+                to_be_appended = cell
+
+            if to_be_appended is not None:
+                if "dmsc-school-hint" in cell["metadata"]["tags"]:
+                    to_be_appended["metadata"]["jupyter"] = {"source_hidden": True}
+                out.append(to_be_appended)
         else:
             out.append(cell)
     obj["cells"] = out


### PR DESCRIPTION
Using the `"dmsc-school-hint"` tag in a cell metadata now adds
```
    "jupyter": {
        "source_hidden": true
    }
```
to the cell metadata which collapses the cell content.

The first line of text remains visible, and a button can be clicked to expand the contents.
This is useful for providing hints to students.
<img width="448" height="305" alt="Screenshot_20250812_135418" src="https://github.com/user-attachments/assets/26acb97f-1d20-4beb-92dd-87561c3f163c" />
<img width="448" height="305" alt="Screenshot_20250812_135434" src="https://github.com/user-attachments/assets/fbb9a4d4-17b9-44c3-be4d-48e46c3dc869" />
