### PR TITLE
Enable html_image myst extension

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,20 @@ author: Data Management and Software Centre
 # logo: logo.png
 copyright: "2025"
 
+parse:
+  myst_enable_extensions:
+    # - amsmath
+    - colon_fence
+    # - deflist
+    - dollarmath
+    # - html_admonition
+    - html_image
+    - linkify
+    # - replacements
+    # - smartquotes
+    - substitution
+    - tasklist
+
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
 execute:


### PR DESCRIPTION
Fixes #166

I tried it locally with the scipp-intro notebook. Let's see if this fixes all missing images.