### PR TITLE
Linkcheck ignore crytsallography.net

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,9 @@ sphinx:
   config:
     nb_execution_show_tb: True
     suppress_warnings: ["myst.xref_missing"]
+    linkcheck_ignore:
+      # Seems to be too unreliable
+      - 'https?://www\.crystallography\.net/'
 
 exclude_patterns:
   - 'article/article.md'


### PR DESCRIPTION
See https://github.com/ess-dmsc-dram/dmsc-school/pull/165#pullrequestreview-3127809623

Not sure if we actually have to do this, the website might come back online. But it's stopping us from building the book at the moment.