### PR TITLE
Comment out matplotlib widget

### DIFF
--- a/4-reduction/scipp-introduction.ipynb
+++ b/4-reduction/scipp-introduction.ipynb
@@ -1541,7 +1541,7 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
+    "# %matplotlib widget\n",
     "\n",
     "da = sc.io.load_hdf5(\"nyc_taxi_data_2015_small.h5\")\n",
     "da"


### PR DESCRIPTION
[This change](https://github.com/ess-dmsc-dram/dmsc-school/pull/169/files#diff-116de8803b95f5bd51f1dff49aaf3bea06f01787d6102fa4bbe980333fd7035aR1544) caused the figures in the second half of the scipp intro notebook to no longer be visible:
<img width="1517" height="838" alt="Screenshot_20250819_135606" src="https://github.com/user-attachments/assets/8c620d37-d546-4c73-b58f-35322deee70a" />
